### PR TITLE
feat: add NFT leasing and revenue sharing contract

### DIFF
--- a/contracts/nft-leasing/Cargo.toml
+++ b/contracts/nft-leasing/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nft-leasing"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/nft-leasing/src/lib.rs
+++ b/contracts/nft-leasing/src/lib.rs
@@ -1,0 +1,477 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, contracterror,
+    panic_with_error, symbol_short,
+    Address, Env, String, Symbol, token,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    LeaseNotFound = 1,
+    LeaseAlreadyActive = 2,
+    LeaseExpired = 3,
+    UnauthorizedCaller = 4,
+    InvalidTerms = 5,
+    InsufficientCollateral = 6,
+    ListingNotFound = 7,
+    DisputeNotFound = 8,
+    LeaseNotTerminable = 9,
+    AlreadyDisputed = 10,
+    InvalidSplit = 11,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LeaseStatus {
+    Pending,
+    Active,
+    Expired,
+    Terminated,
+    Disputed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    Open,
+    ResolvedForLessor,
+    ResolvedForLessee,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LeaseAgreement {
+    pub lease_id: u64,
+    pub lessor: Address,
+    pub lessee: Address,
+    pub nft_id: u64,
+    pub start_time: u64,
+    pub duration: u64,
+    pub lessor_share: u32,
+    pub collateral: i128,
+    pub collateral_deposited: bool,
+    pub status: LeaseStatus,
+    pub total_revenue: i128,
+    pub lessor_earned: i128,
+    pub lessee_earned: i128,
+    pub renewable: bool,
+    pub renewal_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct MarketplaceListing {
+    pub listing_id: u64,
+    pub lessor: Address,
+    pub nft_id: u64,
+    pub lessor_share: u32,
+    pub duration: u64,
+    pub collateral_required: i128,
+    pub active: bool,
+    pub renewable: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct DisputeCase {
+    pub dispute_id: u64,
+    pub lease_id: u64,
+    pub claimant: Address,
+    pub reason: String,
+    pub status: DisputeStatus,
+    pub created_at: u64,
+}
+
+const LEASE_COUNTER: Symbol = symbol_short!("L_CNT");
+const LISTING_COUNTER: Symbol = symbol_short!("LS_CNT");
+const DISPUTE_COUNTER: Symbol = symbol_short!("D_CNT");
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const TOKEN: Symbol = symbol_short!("TOKEN");
+
+#[contracttype]
+pub enum DataKey {
+    Lease(u64),
+    Listing(u64),
+    Dispute(u64),
+}
+
+#[contract]
+pub struct NFTLeasingContract;
+
+#[contractimpl]
+impl NFTLeasingContract {
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&TOKEN, &token);
+        env.storage().instance().set(&LEASE_COUNTER, &0u64);
+        env.storage().instance().set(&LISTING_COUNTER, &0u64);
+        env.storage().instance().set(&DISPUTE_COUNTER, &0u64);
+    }
+
+    pub fn create_lease(
+        env: Env,
+        lessor: Address,
+        lessee: Address,
+        nft_id: u64,
+        duration: u64,
+        lessor_share: u32,
+        collateral: i128,
+        renewable: bool,
+    ) -> u64 {
+        lessor.require_auth();
+
+        if lessor_share > 100 {
+            panic_with_error!(&env, Error::InvalidSplit);
+        }
+        if duration == 0 {
+            panic_with_error!(&env, Error::InvalidTerms);
+        }
+
+        let lease_id: u64 = env.storage().instance().get(&LEASE_COUNTER).unwrap_or(0) + 1;
+        env.storage().instance().set(&LEASE_COUNTER, &lease_id);
+
+        let lease = LeaseAgreement {
+            lease_id,
+            lessor,
+            lessee,
+            nft_id,
+            start_time: 0,
+            duration,
+            lessor_share,
+            collateral,
+            collateral_deposited: collateral == 0,
+            status: LeaseStatus::Pending,
+            total_revenue: 0,
+            lessor_earned: 0,
+            lessee_earned: 0,
+            renewable,
+            renewal_count: 0,
+        };
+
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+        lease_id
+    }
+
+    pub fn deposit_collateral(env: Env, lease_id: u64) {
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+        lease.lessee.require_auth();
+
+        if lease.collateral_deposited {
+            return;
+        }
+
+        let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let lessee = lease.lessee.clone();
+        let collateral = lease.collateral;
+
+        token::Client::new(&env, &token_addr).transfer(
+            &lessee,
+            &env.current_contract_address(),
+            &collateral,
+        );
+
+        lease.collateral_deposited = true;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn activate_lease(env: Env, lease_id: u64) {
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+        lease.lessor.require_auth();
+
+        if lease.status != LeaseStatus::Pending {
+            panic_with_error!(&env, Error::LeaseAlreadyActive);
+        }
+        if !lease.collateral_deposited {
+            panic_with_error!(&env, Error::InsufficientCollateral);
+        }
+
+        lease.start_time = env.ledger().timestamp();
+        lease.status = LeaseStatus::Active;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn record_reward(env: Env, lease_id: u64, amount: i128) {
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+
+        if lease.status != LeaseStatus::Active {
+            panic_with_error!(&env, Error::LeaseExpired);
+        }
+
+        if env.ledger().timestamp() > lease.start_time + lease.duration {
+            lease.status = LeaseStatus::Expired;
+            env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+            panic_with_error!(&env, Error::LeaseExpired);
+        }
+
+        lease.total_revenue += amount;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn distribute_revenue(env: Env, lease_id: u64) {
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+
+        if lease.status != LeaseStatus::Active {
+            panic_with_error!(&env, Error::LeaseExpired);
+        }
+
+        let distributable = lease.total_revenue - (lease.lessor_earned + lease.lessee_earned);
+        if distributable <= 0 {
+            return;
+        }
+
+        let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        let lessor_amount = (distributable * lease.lessor_share as i128) / 100;
+        let lessee_amount = distributable - lessor_amount;
+        let lessor = lease.lessor.clone();
+        let lessee = lease.lessee.clone();
+
+        if lessor_amount > 0 {
+            token_client.transfer(&contract_addr, &lessor, &lessor_amount);
+            lease.lessor_earned += lessor_amount;
+        }
+        if lessee_amount > 0 {
+            token_client.transfer(&contract_addr, &lessee, &lessee_amount);
+            lease.lessee_earned += lessee_amount;
+        }
+
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn renew_lease(env: Env, lease_id: u64, new_duration: u64) {
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+        lease.lessee.require_auth();
+
+        if !lease.renewable {
+            panic_with_error!(&env, Error::InvalidTerms);
+        }
+        if lease.status != LeaseStatus::Active && lease.status != LeaseStatus::Expired {
+            panic_with_error!(&env, Error::LeaseNotTerminable);
+        }
+        if new_duration == 0 {
+            panic_with_error!(&env, Error::InvalidTerms);
+        }
+
+        lease.start_time = env.ledger().timestamp();
+        lease.duration = new_duration;
+        lease.status = LeaseStatus::Active;
+        lease.renewal_count += 1;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn terminate_lease(env: Env, lease_id: u64, caller: Address) {
+        caller.require_auth();
+
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+
+        if caller != lease.lessor && caller != lease.lessee {
+            panic_with_error!(&env, Error::UnauthorizedCaller);
+        }
+        if lease.status == LeaseStatus::Terminated {
+            panic_with_error!(&env, Error::LeaseNotTerminable);
+        }
+
+        let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        let distributable = lease.total_revenue - (lease.lessor_earned + lease.lessee_earned);
+        if distributable > 0 {
+            let lessor_amount = (distributable * lease.lessor_share as i128) / 100;
+            let lessee_amount = distributable - lessor_amount;
+            let lessor = lease.lessor.clone();
+            let lessee = lease.lessee.clone();
+
+            if lessor_amount > 0 {
+                token_client.transfer(&contract_addr, &lessor, &lessor_amount);
+                lease.lessor_earned += lessor_amount;
+            }
+            if lessee_amount > 0 {
+                token_client.transfer(&contract_addr, &lessee, &lessee_amount);
+                lease.lessee_earned += lessee_amount;
+            }
+        }
+
+        if lease.collateral > 0 && lease.collateral_deposited {
+            let lessee = lease.lessee.clone();
+            let collateral = lease.collateral;
+            token_client.transfer(&contract_addr, &lessee, &collateral);
+        }
+
+        lease.status = LeaseStatus::Terminated;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn list_on_marketplace(
+        env: Env,
+        lessor: Address,
+        nft_id: u64,
+        lessor_share: u32,
+        duration: u64,
+        collateral_required: i128,
+        renewable: bool,
+    ) -> u64 {
+        lessor.require_auth();
+
+        if lessor_share > 100 {
+            panic_with_error!(&env, Error::InvalidSplit);
+        }
+
+        let listing_id: u64 = env.storage().instance().get(&LISTING_COUNTER).unwrap_or(0) + 1;
+        env.storage().instance().set(&LISTING_COUNTER, &listing_id);
+
+        let listing = MarketplaceListing {
+            listing_id,
+            lessor,
+            nft_id,
+            lessor_share,
+            duration,
+            collateral_required,
+            active: true,
+            renewable,
+        };
+
+        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
+        listing_id
+    }
+
+    pub fn take_marketplace_listing(env: Env, listing_id: u64, lessee: Address) -> u64 {
+        lessee.require_auth();
+
+        let mut listing: MarketplaceListing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::ListingNotFound));
+
+        if !listing.active {
+            panic_with_error!(&env, Error::ListingNotFound);
+        }
+
+        listing.active = false;
+        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
+
+        let lease_id: u64 = env.storage().instance().get(&LEASE_COUNTER).unwrap_or(0) + 1;
+        env.storage().instance().set(&LEASE_COUNTER, &lease_id);
+
+        let collateral_deposited = listing.collateral_required == 0;
+        let lease = LeaseAgreement {
+            lease_id,
+            lessor: listing.lessor.clone(),
+            lessee,
+            nft_id: listing.nft_id,
+            start_time: 0,
+            duration: listing.duration,
+            lessor_share: listing.lessor_share,
+            collateral: listing.collateral_required,
+            collateral_deposited,
+            status: LeaseStatus::Pending,
+            total_revenue: 0,
+            lessor_earned: 0,
+            lessee_earned: 0,
+            renewable: listing.renewable,
+            renewal_count: 0,
+        };
+
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+        lease_id
+    }
+
+    pub fn open_dispute(env: Env, lease_id: u64, claimant: Address, reason: String) -> u64 {
+        claimant.require_auth();
+
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+
+        if claimant != lease.lessor && claimant != lease.lessee {
+            panic_with_error!(&env, Error::UnauthorizedCaller);
+        }
+        if lease.status == LeaseStatus::Disputed {
+            panic_with_error!(&env, Error::AlreadyDisputed);
+        }
+
+        let dispute_id: u64 = env.storage().instance().get(&DISPUTE_COUNTER).unwrap_or(0) + 1;
+        env.storage().instance().set(&DISPUTE_COUNTER, &dispute_id);
+
+        let dispute = DisputeCase {
+            dispute_id,
+            lease_id,
+            claimant,
+            reason,
+            status: DisputeStatus::Open,
+            created_at: env.ledger().timestamp(),
+        };
+
+        lease.status = LeaseStatus::Disputed;
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+        env.storage().persistent().set(&DataKey::Dispute(dispute_id), &dispute);
+        dispute_id
+    }
+
+    pub fn resolve_dispute(env: Env, dispute_id: u64, favor_lessor: bool) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+
+        let mut dispute: DisputeCase = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Dispute(dispute_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::DisputeNotFound));
+
+        let lease_id = dispute.lease_id;
+        let mut lease = Self::get_lease(env.clone(), lease_id);
+
+        let token_addr: Address = env.storage().instance().get(&TOKEN).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        if lease.collateral > 0 && lease.collateral_deposited {
+            let collateral = lease.collateral;
+            if favor_lessor {
+                let lessor = lease.lessor.clone();
+                token_client.transfer(&contract_addr, &lessor, &collateral);
+            } else {
+                let lessee = lease.lessee.clone();
+                token_client.transfer(&contract_addr, &lessee, &collateral);
+            }
+        }
+
+        dispute.status = if favor_lessor {
+            DisputeStatus::ResolvedForLessor
+        } else {
+            DisputeStatus::ResolvedForLessee
+        };
+
+        lease.status = LeaseStatus::Terminated;
+        env.storage().persistent().set(&DataKey::Dispute(dispute_id), &dispute);
+        env.storage().persistent().set(&DataKey::Lease(lease_id), &lease);
+    }
+
+    pub fn get_lease(env: Env, lease_id: u64) -> LeaseAgreement {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Lease(lease_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::LeaseNotFound))
+    }
+
+    pub fn get_listing(env: Env, listing_id: u64) -> MarketplaceListing {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Listing(listing_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::ListingNotFound))
+    }
+
+    pub fn get_dispute(env: Env, dispute_id: u64) -> DisputeCase {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Dispute(dispute_id))
+            .unwrap_or_else(|| panic_with_error!(&env, Error::DisputeNotFound))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/nft-leasing/src/test.rs
+++ b/contracts/nft-leasing/src/test.rs
@@ -1,0 +1,437 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+    token::{Client as TokenClient, StellarAssetClient},
+};
+
+struct TestSetup {
+    env: Env,
+    contract_id: Address,
+    token_id: Address,
+    admin: Address,
+    lessor: Address,
+    lessee: Address,
+}
+
+fn setup() -> TestSetup {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let lessor = Address::generate(&env);
+    let lessee = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract(admin.clone());
+    let contract_id = env.register_contract(None, NFTLeasingContract);
+
+    let client = NFTLeasingContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_id);
+
+    let sac = StellarAssetClient::new(&env, &token_id);
+    sac.mint(&lessee, &1_000_000);
+
+    TestSetup { env, contract_id, token_id, admin, lessor, lessee }
+}
+
+fn mint_to_contract(setup: &TestSetup, amount: i128) {
+    let sac = StellarAssetClient::new(&setup.env, &setup.token_id);
+    sac.mint(&setup.contract_id, &amount);
+}
+
+#[test]
+fn test_create_lease() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &1u64, &86400u64, &70u32, &0i128, &false,
+    );
+    assert_eq!(lease_id, 1);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.lessor, s.lessor);
+    assert_eq!(lease.lessee, s.lessee);
+    assert_eq!(lease.nft_id, 1);
+    assert_eq!(lease.lessor_share, 70);
+    assert_eq!(lease.status, LeaseStatus::Pending);
+    assert!(lease.collateral_deposited);
+}
+
+#[test]
+fn test_activate_lease_no_collateral() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &1u64, &86400u64, &60u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Active);
+}
+
+#[test]
+fn test_collateral_deposit_and_activate() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let collateral = 10_000i128;
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &2u64, &86400u64, &50u32, &collateral, &false,
+    );
+
+    let lease = client.get_lease(&lease_id);
+    assert!(!lease.collateral_deposited);
+
+    client.deposit_collateral(&lease_id);
+
+    let lease = client.get_lease(&lease_id);
+    assert!(lease.collateral_deposited);
+    assert_eq!(token.balance(&s.contract_id), collateral);
+
+    client.activate_lease(&lease_id);
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Active);
+}
+
+#[test]
+fn test_record_reward_and_distribute() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &3u64, &86400u64, &70u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    let reward = 1_000i128;
+    mint_to_contract(&s, reward);
+
+    client.record_reward(&lease_id, &reward);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.total_revenue, reward);
+
+    let lessor_before = token.balance(&s.lessor);
+    let lessee_before = token.balance(&s.lessee);
+
+    client.distribute_revenue(&lease_id);
+
+    assert_eq!(token.balance(&s.lessor), lessor_before + 700);
+    assert_eq!(token.balance(&s.lessee), lessee_before + 300);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.lessor_earned, 700);
+    assert_eq!(lease.lessee_earned, 300);
+}
+
+#[test]
+fn test_multiple_reward_distributions() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &4u64, &86400u64, &60u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    mint_to_contract(&s, 2_000);
+    client.record_reward(&lease_id, &1_000);
+    client.distribute_revenue(&lease_id);
+
+    client.record_reward(&lease_id, &1_000);
+    client.distribute_revenue(&lease_id);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.total_revenue, 2_000);
+    assert_eq!(lease.lessor_earned, 1_200);
+    assert_eq!(lease.lessee_earned, 800);
+    assert_eq!(token.balance(&s.lessor), 1_200);
+    assert_eq!(token.balance(&s.lessee), 999_800 + 800);
+}
+
+#[test]
+fn test_lease_renewal() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &5u64, &1000u64, &50u32, &0i128, &true,
+    );
+    client.activate_lease(&lease_id);
+
+    s.env.ledger().with_mut(|li| li.timestamp = 2000);
+
+    client.renew_lease(&lease_id, &5000u64);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Active);
+    assert_eq!(lease.duration, 5000);
+    assert_eq!(lease.renewal_count, 1);
+}
+
+#[test]
+fn test_lease_termination_returns_collateral() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let collateral = 5_000i128;
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &6u64, &86400u64, &50u32, &collateral, &false,
+    );
+
+    client.deposit_collateral(&lease_id);
+    client.activate_lease(&lease_id);
+
+    let lessee_before = token.balance(&s.lessee);
+    client.terminate_lease(&lease_id, &s.lessor);
+
+    assert_eq!(token.balance(&s.lessee), lessee_before + collateral);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Terminated);
+}
+
+#[test]
+fn test_terminate_distributes_remaining_revenue() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &7u64, &86400u64, &80u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    mint_to_contract(&s, 500);
+    client.record_reward(&lease_id, &500);
+
+    let lessor_before = token.balance(&s.lessor);
+    let lessee_before = token.balance(&s.lessee);
+
+    client.terminate_lease(&lease_id, &s.lessee);
+
+    assert_eq!(token.balance(&s.lessor), lessor_before + 400);
+    assert_eq!(token.balance(&s.lessee), lessee_before + 100);
+}
+
+#[test]
+fn test_marketplace_listing_and_take() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let listing_id = client.list_on_marketplace(
+        &s.lessor, &8u64, &60u32, &86400u64, &0i128, &true,
+    );
+    assert_eq!(listing_id, 1);
+
+    let listing = client.get_listing(&listing_id);
+    assert!(listing.active);
+    assert_eq!(listing.lessor_share, 60);
+
+    let lease_id = client.take_marketplace_listing(&listing_id, &s.lessee);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.lessor, s.lessor);
+    assert_eq!(lease.lessee, s.lessee);
+    assert_eq!(lease.nft_id, 8);
+    assert_eq!(lease.status, LeaseStatus::Pending);
+    assert!(lease.renewable);
+
+    let listing = client.get_listing(&listing_id);
+    assert!(!listing.active);
+}
+
+#[test]
+fn test_marketplace_listing_with_collateral() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let listing_id = client.list_on_marketplace(
+        &s.lessor, &9u64, &70u32, &3600u64, &2_000i128, &false,
+    );
+
+    let lease_id = client.take_marketplace_listing(&listing_id, &s.lessee);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.collateral, 2_000);
+    assert!(!lease.collateral_deposited);
+
+    client.deposit_collateral(&lease_id);
+    client.activate_lease(&lease_id);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Active);
+}
+
+#[test]
+fn test_open_and_resolve_dispute_favor_lessor() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let collateral = 3_000i128;
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &10u64, &86400u64, &50u32, &collateral, &false,
+    );
+    client.deposit_collateral(&lease_id);
+    client.activate_lease(&lease_id);
+
+    let reason = String::from_str(&s.env, "Lessee violated terms");
+    let dispute_id = client.open_dispute(&lease_id, &s.lessor, &reason);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Disputed);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::Open);
+
+    let lessor_before = token.balance(&s.lessor);
+    client.resolve_dispute(&dispute_id, &true);
+
+    assert_eq!(token.balance(&s.lessor), lessor_before + collateral);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::ResolvedForLessor);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Terminated);
+}
+
+#[test]
+fn test_open_and_resolve_dispute_favor_lessee() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let collateral = 2_000i128;
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &11u64, &86400u64, &50u32, &collateral, &false,
+    );
+    client.deposit_collateral(&lease_id);
+    client.activate_lease(&lease_id);
+
+    let reason = String::from_str(&s.env, "Lessor withheld NFT access");
+    let dispute_id = client.open_dispute(&lease_id, &s.lessee, &reason);
+
+    let lessee_before = token.balance(&s.lessee);
+    client.resolve_dispute(&dispute_id, &false);
+
+    assert_eq!(token.balance(&s.lessee), lessee_before + collateral);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::ResolvedForLessee);
+}
+
+#[test]
+fn test_lease_expiry_on_reward_record() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &12u64, &1000u64, &50u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    s.env.ledger().with_mut(|li| li.timestamp = 5000);
+
+    let result = client.try_record_reward(&lease_id, &100i128);
+    assert!(result.is_err());
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Expired);
+}
+
+#[test]
+fn test_invalid_split_rejected() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let result = client.try_create_lease(
+        &s.lessor, &s.lessee, &1u64, &86400u64, &101u32, &0i128, &false,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidSplit)));
+}
+
+#[test]
+fn test_zero_duration_rejected() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let result = client.try_create_lease(
+        &s.lessor, &s.lessee, &1u64, &0u64, &50u32, &0i128, &false,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidTerms)));
+}
+
+#[test]
+fn test_non_renewable_lease_cannot_renew() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &13u64, &86400u64, &50u32, &0i128, &false,
+    );
+    client.activate_lease(&lease_id);
+
+    let result = client.try_renew_lease(&lease_id, &86400u64);
+    assert_eq!(result, Err(Ok(Error::InvalidTerms)));
+}
+
+#[test]
+fn test_activate_without_collateral_rejected() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &14u64, &86400u64, &50u32, &5_000i128, &false,
+    );
+
+    let result = client.try_activate_lease(&lease_id);
+    assert_eq!(result, Err(Ok(Error::InsufficientCollateral)));
+}
+
+#[test]
+fn test_full_lease_flow() {
+    let s = setup();
+    let client = NFTLeasingContractClient::new(&s.env, &s.contract_id);
+    let token = TokenClient::new(&s.env, &s.token_id);
+
+    let collateral = 1_000i128;
+    let lease_id = client.create_lease(
+        &s.lessor, &s.lessee, &99u64, &86400u64, &70u32, &collateral, &true,
+    );
+
+    client.deposit_collateral(&lease_id);
+    client.activate_lease(&lease_id);
+
+    mint_to_contract(&s, 3_000);
+    client.record_reward(&lease_id, &1_000);
+    client.record_reward(&lease_id, &2_000);
+    client.distribute_revenue(&lease_id);
+
+    assert_eq!(token.balance(&s.lessor), 2_100);
+    assert_eq!(token.balance(&s.lessee), 998_000 + 900);
+
+    s.env.ledger().with_mut(|li| li.timestamp = 100_000);
+    client.renew_lease(&lease_id, &86400u64);
+
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.renewal_count, 1);
+    assert_eq!(lease.status, LeaseStatus::Active);
+
+    client.terminate_lease(&lease_id, &s.lessor);
+
+    let final_lessee_balance = token.balance(&s.lessee);
+    let lease = client.get_lease(&lease_id);
+    assert_eq!(lease.status, LeaseStatus::Terminated);
+    assert_eq!(final_lessee_balance, 998_000 + 900 + collateral);
+}


### PR DESCRIPTION
 Description:
  Implements an on-chain NFT leasing system on Stellar/Soroban allowing NFT owners to lease assets to players and
  automatically split earned rewards.

  Changes:
  - Lease agreement structure with status lifecycle (Pending → Active → Expired/Terminated/Disputed)
  - Lease creation, collateral deposit, and activation flow
  - Revenue tracking and automatic split distribution by configurable lessor_share percentage
  - Lease renewal support with renewal counter
  - Lease termination with revenue flush and collateral refund
  - Marketplace for listing and taking NFT lease offers
  - Dispute system with admin-controlled resolution and collateral ruling
  - 13 tests covering full leasing flow, error cases, and dispute scenarios

closes #114 