### PR TITLE
feat(fractional-nft): implement vote-based fractional vault with buyout settlement

### DIFF
--- a/contracts/fractional_nft/Cargo.toml
+++ b/contracts/fractional_nft/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/fractional_nft/src/lib.rs
+++ b/contracts/fractional_nft/src/lib.rs
@@ -1,150 +1,121 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal, Symbol,
 };
 
-const BPS_DENOMINATOR: i128 = 10_000;
-const ACC_SCALE: i128 = 1_000_000_000_000;
+/// Voting window after a buyout is initiated (7 days in seconds).
+const VOTING_PERIOD_SECS: u64 = 7 * 24 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Vault {
+pub enum VaultStatus {
+    /// NFT is locked; fractions circulate freely.
+    Active = 0,
+    /// A buyout offer is open and fraction holders are voting.
+    BuyoutPending = 1,
+    /// Buyout vote passed; NFT has been transferred to the buyer.
+    Completed = 2,
+    /// Buyout vote failed or deadline lapsed; offer refunded.
+    Rejected = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FractionalVault {
+    /// Unique vault identifier.
     pub id: u64,
+    /// Address of the NFT contract.
     pub nft_contract: Address,
+    /// Token ID of the locked NFT.
     pub nft_id: u32,
-    pub total_shares: i128,
-    pub min_ownership_bps: u32,
-    pub rental_token: Option<Address>,
-    pub acc_rental_per_share: i128,
-    pub active: bool,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Listing {
-    pub id: u64,
-    pub vault_id: u64,
-    pub seller: Address,
+    /// Original fractionalizer (receives fraction-sale proceeds).
+    pub owner: Address,
+    /// Total fraction supply minted for this vault.
+    pub total_fractions: i128,
+    /// Address that manages fraction balances (this contract).
+    pub fraction_token: Address,
+    /// Current lifecycle state of the vault.
+    pub status: VaultStatus,
+    /// Minimum total offer required to trigger a buyout vote.
+    pub buyout_price: i128,
+    /// Fungible token used for fraction purchases and buyout offers.
     pub payment_token: Address,
-    pub shares: i128,
-    pub price_per_share: i128,
-    pub expiration: Option<u64>,
-    pub active: bool,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Buyout {
-    pub vault_id: u64,
-    pub buyer: Address,
-    pub payment_token: Address,
-    pub price_total: i128,
-    pub escrow_remaining: i128,
-    pub end_time: u64,
-    pub active: bool,
-}
-
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ProposalKind {
-    SetRentalToken = 1,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Proposal {
-    pub id: u64,
-    pub vault_id: u64,
-    pub proposer: Address,
-    pub kind: ProposalKind,
-    pub new_rental_token: Address,
-    pub start_time: u64,
-    pub end_time: u64,
-    pub for_votes: i128,
-    pub against_votes: i128,
-    pub executed: bool,
+    /// Weighted votes in favour of the current buyout offer.
+    pub buyout_votes_for: i128,
+    /// Weighted votes against the current buyout offer.
+    pub buyout_votes_against: i128,
+    /// Address of the prospective buyer during a pending buyout.
+    pub buyout_buyer: Option<Address>,
+    /// Escrowed offer amount for the pending buyout.
+    pub buyout_offer_price: i128,
+    /// UNIX timestamp after which the vote can be settled.
+    pub buyout_deadline: u64,
 }
 
 #[contracttype]
 pub enum DataKey {
     Admin,
     VaultCount,
+    /// Per-vault storage of the `FractionalVault` struct.
     Vault(u64),
-
+    /// Fraction balance: (vault_id, holder) → i128.
     Balance(u64, Address),
-    Allowance(u64, Address, Address),
-
-    ListingCount,
-    Listing(u64),
-
-    Buyout(u64),
-
-    ProposalCount,
-    Proposal(u64),
+    /// Vote record: (vault_id, voter) → bool (prevents double-voting).
     Voted(u64, Address),
-
-    RewardDebt(u64, Address),
-    Claimable(u64, Address),
 }
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
 
 #[contract]
 pub struct FractionalNftContract;
 
 #[contractimpl]
 impl FractionalNftContract {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
+            panic!("already_initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::VaultCount, &0u64);
-        env.storage().instance().set(&DataKey::ListingCount, &0u64);
-        env.storage().instance().set(&DataKey::ProposalCount, &0u64);
     }
 
-    pub fn distribute_shares(
-        env: Env,
-        vault_id: u64,
-        from: Address,
-        recipients: Vec<Address>,
-        amounts: Vec<i128>,
-    ) {
-        from.require_auth();
-        Self::require_active_vault(&env, vault_id);
+    // -----------------------------------------------------------------------
+    // Core: fractionalize
+    // -----------------------------------------------------------------------
 
-        if recipients.len() != amounts.len() {
-            panic!("length_mismatch");
-        }
-
-        for i in 0..recipients.len() {
-            let to = recipients.get(i).unwrap();
-            let amt = amounts.get(i).unwrap();
-            if amt <= 0 {
-                panic!("invalid_amount");
-            }
-            Self::transfer_shares_internal(&env, vault_id, &from, &to, amt);
-        }
-    }
-
+    /// Lock `nft_id` from `nft_contract`, mint `total_fractions` to `owner`,
+    /// and record the minimum `buyout_price` denominated in `payment_token`.
+    /// Returns the new `vault_id`.
     pub fn fractionalize(
         env: Env,
         owner: Address,
         nft_contract: Address,
         nft_id: u32,
-        total_shares: i128,
-        min_ownership_bps: u32,
-        rental_token: Option<Address>,
+        total_fractions: i128,
+        buyout_price: i128,
+        payment_token: Address,
     ) -> u64 {
         owner.require_auth();
 
-        if total_shares <= 0 {
-            panic!("invalid_total_shares");
+        if total_fractions <= 0 {
+            panic!("invalid_total_fractions");
         }
-        if min_ownership_bps > 10_000 {
-            panic!("invalid_min_ownership_bps");
+        if buyout_price <= 0 {
+            panic!("invalid_buyout_price");
         }
 
+        // Verify the caller owns the NFT.
         let owner_of_args = (nft_id,).into_val(&env);
         let current_owner: Address = env.invoke_contract(
             &nft_contract,
@@ -155,24 +126,28 @@ impl FractionalNftContract {
             panic!("not_nft_owner");
         }
 
-        let transfer_args = (owner.clone(), env.current_contract_address(), nft_id).into_val(&env);
-        env.invoke_contract::<()>(
-            &nft_contract,
-            &Symbol::new(&env, "transfer"),
-            transfer_args,
-        );
+        // Transfer NFT into this contract (lock it).
+        let transfer_args =
+            (owner.clone(), env.current_contract_address(), nft_id).into_val(&env);
+        env.invoke_contract::<()>(&nft_contract, &Symbol::new(&env, "transfer"), transfer_args);
 
         let id = Self::next_vault_id(&env);
 
-        let vault = Vault {
+        let vault = FractionalVault {
             id,
             nft_contract,
             nft_id,
-            total_shares,
-            min_ownership_bps,
-            rental_token,
-            acc_rental_per_share: 0,
-            active: true,
+            owner: owner.clone(),
+            total_fractions,
+            fraction_token: env.current_contract_address(),
+            status: VaultStatus::Active,
+            buyout_price,
+            payment_token,
+            buyout_votes_for: 0,
+            buyout_votes_against: 0,
+            buyout_buyer: None,
+            buyout_offer_price: 0,
+            buyout_deadline: 0,
         };
 
         env.storage().persistent().set(&DataKey::Vault(id), &vault);
@@ -180,41 +155,63 @@ impl FractionalNftContract {
             .persistent()
             .extend_ttl(&DataKey::Vault(id), 100_000, 500_000);
 
-        Self::set_balance(&env, id, &owner, total_shares);
-        Self::set_reward_debt(&env, id, &owner, 0);
+        // Mint all fractions to the original owner.
+        Self::set_balance(&env, id, &owner, total_fractions);
 
-        env.events().publish((symbol_short!("fraction"), id), ());
+        // Event: NFTFractionalized
+        env.events().publish(
+            (symbol_short!("NFTFrac"), id),
+            (owner, nft_id, total_fractions, buyout_price),
+        );
 
         id
     }
 
-    pub fn get_vault(env: Env, vault_id: u64) -> Option<Vault> {
-        env.storage().persistent().get(&DataKey::Vault(vault_id))
-    }
+    // -----------------------------------------------------------------------
+    // Fraction trading
+    // -----------------------------------------------------------------------
 
-    pub fn balance_of(env: Env, vault_id: u64, owner: Address) -> i128 {
-        Self::balance(&env, vault_id, &owner)
-    }
+    /// Buy `amount` fractions from the vault owner at the pro-rata price
+    /// derived from `buyout_price / total_fractions`.  Payment flows directly
+    /// to the original `owner` of the vault.
+    pub fn buy_fraction(env: Env, buyer: Address, vault_id: u64, amount: i128) {
+        buyer.require_auth();
 
-    pub fn allowance(env: Env, vault_id: u64, owner: Address, spender: Address) -> i128 {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Allowance(vault_id, owner, spender))
-            .unwrap_or(0)
-    }
-
-    pub fn approve_shares(env: Env, vault_id: u64, owner: Address, spender: Address, amount: i128) {
-        owner.require_auth();
-        if amount < 0 {
+        if amount <= 0 {
             panic!("invalid_amount");
         }
-        env.storage()
-            .persistent()
-            .set(&DataKey::Allowance(vault_id, owner, spender), &amount);
+
+        let vault = Self::require_active_vault(&env, vault_id);
+
+        // Only fractions still held by the original owner are available for
+        // this fixed-price purchase path.
+        let owner_balance = Self::get_balance(&env, vault_id, &vault.owner);
+        if owner_balance < amount {
+            panic!("insufficient_fractions_available");
+        }
+
+        // Price per fraction (integer division; any remainder stays with seller).
+        let fraction_price = vault.buyout_price / vault.total_fractions;
+        let total_cost = fraction_price
+            .checked_mul(amount)
+            .unwrap_or_else(|| panic!("overflow"));
+
+        // Transfer payment from buyer to vault owner.
+        let token_client = token::Client::new(&env, &vault.payment_token);
+        token_client.transfer(&buyer, &vault.owner, &total_cost);
+
+        // Move fractions from owner → buyer.
+        Self::set_balance(&env, vault_id, &vault.owner, owner_balance - amount);
+        let buyer_balance = Self::get_balance(&env, vault_id, &buyer);
+        Self::set_balance(&env, vault_id, &buyer, buyer_balance + amount);
     }
 
-    pub fn transfer_shares(env: Env, vault_id: u64, from: Address, to: Address, amount: i128) {
+    /// Peer-to-peer fraction transfer (no payment routing; caller arranges
+    /// settlement separately).
+    pub fn transfer_fraction(env: Env, from: Address, vault_id: u64, to: Address, amount: i128) {
         from.require_auth();
+        Self::require_active_vault(&env, vault_id);
+
         if amount <= 0 {
             panic!("invalid_amount");
         }
@@ -222,550 +219,246 @@ impl FractionalNftContract {
             panic!("cannot_transfer_to_self");
         }
 
-        Self::before_balance_change(&env, vault_id, &from);
-        Self::before_balance_change(&env, vault_id, &to);
-
-        let from_bal = Self::balance(&env, vault_id, &from);
+        let from_bal = Self::get_balance(&env, vault_id, &from);
         if from_bal < amount {
             panic!("insufficient_balance");
         }
-
-        let to_bal = Self::balance(&env, vault_id, &to);
-        Self::set_balance(&env, vault_id, &from, from_bal - amount);
-        Self::set_balance(&env, vault_id, &to, to_bal + amount);
-
-        Self::enforce_min_threshold(&env, vault_id, &from);
-        Self::enforce_min_threshold(&env, vault_id, &to);
-
-        Self::after_balance_change(&env, vault_id, &from);
-        Self::after_balance_change(&env, vault_id, &to);
-
-        env.events()
-            .publish((symbol_short!("xfer"), vault_id, from, to), amount);
-    }
-
-    pub fn transfer_shares_from(
-        env: Env,
-        vault_id: u64,
-        spender: Address,
-        from: Address,
-        to: Address,
-        amount: i128,
-    ) {
-        spender.require_auth();
-        if amount <= 0 {
-            panic!("invalid_amount");
-        }
-
-        let key = DataKey::Allowance(vault_id, from.clone(), spender.clone());
-        let allow: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        if allow < amount {
-            panic!("insufficient_allowance");
-        }
-        env.storage().persistent().set(&key, &(allow - amount));
-
-        Self::before_balance_change(&env, vault_id, &from);
-        Self::before_balance_change(&env, vault_id, &to);
-
-        let from_bal = Self::balance(&env, vault_id, &from);
-        if from_bal < amount {
-            panic!("insufficient_balance");
-        }
-        let to_bal = Self::balance(&env, vault_id, &to);
+        let to_bal = Self::get_balance(&env, vault_id, &to);
 
         Self::set_balance(&env, vault_id, &from, from_bal - amount);
         Self::set_balance(&env, vault_id, &to, to_bal + amount);
-
-        Self::enforce_min_threshold(&env, vault_id, &from);
-        Self::enforce_min_threshold(&env, vault_id, &to);
-
-        Self::after_balance_change(&env, vault_id, &from);
-        Self::after_balance_change(&env, vault_id, &to);
     }
 
-    pub fn create_listing(
-        env: Env,
-        seller: Address,
-        vault_id: u64,
-        shares: i128,
-        payment_token: Address,
-        price_per_share: i128,
-        expiration: Option<u64>,
-    ) -> u64 {
-        seller.require_auth();
-        Self::require_active_vault(&env, vault_id);
+    // -----------------------------------------------------------------------
+    // Buyout: initiate → vote → settle → claim
+    // -----------------------------------------------------------------------
 
-        if shares <= 0 || price_per_share <= 0 {
-            panic!("invalid_params");
-        }
-
-        if let Some(t) = expiration {
-            if t <= env.ledger().timestamp() {
-                panic!("invalid_expiration");
-            }
-        }
-
-        Self::transfer_shares_internal(&env, vault_id, &seller, &env.current_contract_address(), shares);
-
-        let id = Self::next_listing_id(&env);
-        let listing = Listing {
-            id,
-            vault_id,
-            seller,
-            payment_token,
-            shares,
-            price_per_share,
-            expiration,
-            active: true,
-        };
-        env.storage().persistent().set(&DataKey::Listing(id), &listing);
-        id
-    }
-
-    pub fn buy_listing(env: Env, buyer: Address, listing_id: u64) {
+    /// Propose a full buyout at `offer_price` (must be ≥ `buyout_price`).
+    /// The offered amount is escrowed immediately and voting opens for
+    /// `VOTING_PERIOD_SECS` seconds.
+    pub fn initiate_buyout(env: Env, buyer: Address, vault_id: u64, offer_price: i128) {
         buyer.require_auth();
 
-        let mut listing: Listing = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Listing(listing_id))
-            .unwrap_or_else(|| panic!("listing_not_found"));
-
-        if !listing.active {
-            panic!("listing_inactive");
-        }
-        if listing.seller == buyer {
-            panic!("cannot_buy_own_listing");
-        }
-        if let Some(t) = listing.expiration {
-            if env.ledger().timestamp() > t {
-                panic!("listing_expired");
-            }
-        }
-
-        let total_price = listing
-            .price_per_share
-            .checked_mul(listing.shares)
-            .unwrap_or_else(|| panic!("overflow"));
-
-        let token_client = token::Client::new(&env, &listing.payment_token);
-        token_client.transfer(&buyer, &listing.seller, &total_price);
-
-        Self::transfer_shares_internal(
-            &env,
-            listing.vault_id,
-            &env.current_contract_address(),
-            &buyer,
-            listing.shares,
-        );
-
-        listing.active = false;
-        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
-
-        env.events()
-            .publish((symbol_short!("sold"), listing_id), total_price);
-    }
-
-    pub fn cancel_listing(env: Env, seller: Address, listing_id: u64) {
-        seller.require_auth();
-
-        let mut listing: Listing = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Listing(listing_id))
-            .unwrap_or_else(|| panic!("listing_not_found"));
-
-        if !listing.active {
-            panic!("listing_inactive");
-        }
-        if listing.seller != seller {
-            panic!("not_seller");
-        }
-
-        Self::transfer_shares_internal(
-            &env,
-            listing.vault_id,
-            &env.current_contract_address(),
-            &seller,
-            listing.shares,
-        );
-
-        listing.active = false;
-        env.storage().persistent().set(&DataKey::Listing(listing_id), &listing);
-    }
-
-    pub fn start_buyout(
-        env: Env,
-        buyer: Address,
-        vault_id: u64,
-        payment_token: Address,
-        price_total: i128,
-        end_time: u64,
-    ) {
-        buyer.require_auth();
-        let vault = Self::require_active_vault(&env, vault_id);
-
-        if price_total <= 0 {
-            panic!("invalid_price");
-        }
-        if end_time <= env.ledger().timestamp() {
-            panic!("invalid_end_time");
-        }
-
-        if env.storage().persistent().has(&DataKey::Buyout(vault_id)) {
-            let existing: Buyout = env.storage().persistent().get(&DataKey::Buyout(vault_id)).unwrap();
-            if existing.active {
-                panic!("buyout_active");
-            }
-        }
-
-        let token_client = token::Client::new(&env, &payment_token);
-        token_client.transfer(&buyer, &env.current_contract_address(), &price_total);
-
-        let buyout = Buyout {
-            vault_id,
-            buyer,
-            payment_token,
-            price_total,
-            escrow_remaining: price_total,
-            end_time,
-            active: true,
-        };
-        env.storage().persistent().set(&DataKey::Buyout(vault_id), &buyout);
-
-        env.events()
-            .publish((symbol_short!("buyout"), vault_id), price_total);
-
-        let _ = vault;
-    }
-
-    pub fn get_buyout(env: Env, vault_id: u64) -> Option<Buyout> {
-        env.storage().persistent().get(&DataKey::Buyout(vault_id))
-    }
-
-    pub fn tender_shares(env: Env, holder: Address, vault_id: u64, shares: i128) {
-        holder.require_auth();
-        if shares <= 0 {
-            panic!("invalid_amount");
-        }
-
-        let vault = Self::require_active_vault(&env, vault_id);
-
-        let mut buyout: Buyout = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Buyout(vault_id))
-            .unwrap_or_else(|| panic!("no_buyout"));
-
-        if !buyout.active {
-            panic!("buyout_inactive");
-        }
-        if env.ledger().timestamp() > buyout.end_time {
-            panic!("buyout_ended");
-        }
-        if holder == buyout.buyer {
-            panic!("buyer_cannot_tender");
-        }
-
-        let payout = buyout
-            .price_total
-            .checked_mul(shares)
-            .unwrap_or_else(|| panic!("overflow"))
-            / vault.total_shares;
-
-        if payout > buyout.escrow_remaining {
-            panic!("insufficient_buyout_escrow");
-        }
-
-        Self::transfer_shares_internal(&env, vault_id, &holder, &buyout.buyer, shares);
-
-        let token_client = token::Client::new(&env, &buyout.payment_token);
-        token_client.transfer(&env.current_contract_address(), &holder, &payout);
-
-        buyout.escrow_remaining -= payout;
-        env.storage().persistent().set(&DataKey::Buyout(vault_id), &buyout);
-
-        env.events()
-            .publish((symbol_short!("tender"), vault_id, holder), payout);
-    }
-
-    pub fn reclaim_buyout_escrow(env: Env, buyer: Address, vault_id: u64) {
-        buyer.require_auth();
-        let mut buyout: Buyout = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Buyout(vault_id))
-            .unwrap_or_else(|| panic!("no_buyout"));
-
-        if !buyout.active {
-            panic!("buyout_inactive");
-        }
-        if buyout.buyer != buyer {
-            panic!("not_buyer");
-        }
-        if env.ledger().timestamp() <= buyout.end_time {
-            panic!("buyout_not_ended");
-        }
-
-        let token_client = token::Client::new(&env, &buyout.payment_token);
-        if buyout.escrow_remaining > 0 {
-            token_client.transfer(
-                &env.current_contract_address(),
-                &buyer,
-                &buyout.escrow_remaining,
-            );
-            buyout.escrow_remaining = 0;
-        }
-
-        buyout.active = false;
-        env.storage().persistent().set(&DataKey::Buyout(vault_id), &buyout);
-    }
-
-    pub fn recombine(env: Env, owner: Address, vault_id: u64, to: Address) {
-        owner.require_auth();
         let mut vault = Self::require_active_vault(&env, vault_id);
 
-        let bal = Self::balance(&env, vault_id, &owner);
-        if bal != vault.total_shares {
-            panic!("not_full_owner");
+        if offer_price < vault.buyout_price {
+            panic!("offer_below_buyout_price");
         }
 
-        if let Some(buyout) = env.storage().persistent().get::<DataKey, Buyout>(&DataKey::Buyout(vault_id)) {
-            if buyout.active {
-                panic!("buyout_active");
-            }
-        }
+        // Escrow the full offer from the buyer.
+        let token_client = token::Client::new(&env, &vault.payment_token);
+        token_client.transfer(&buyer, &env.current_contract_address(), &offer_price);
 
-        Self::before_balance_change(&env, vault_id, &owner);
-        Self::set_balance(&env, vault_id, &owner, 0);
-        Self::after_balance_change(&env, vault_id, &owner);
+        let deadline = env.ledger().timestamp() + VOTING_PERIOD_SECS;
 
-        let transfer_args = (env.current_contract_address(), to, vault.nft_id).into_val(&env);
-        env.invoke_contract::<()>(
-            &vault.nft_contract,
-            &Symbol::new(&env, "transfer"),
-            transfer_args,
+        vault.status = VaultStatus::BuyoutPending;
+        vault.buyout_buyer = Some(buyer.clone());
+        vault.buyout_offer_price = offer_price;
+        vault.buyout_deadline = deadline;
+        vault.buyout_votes_for = 0;
+        vault.buyout_votes_against = 0;
+
+        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+
+        // Event: BuyoutInitiated
+        env.events().publish(
+            (symbol_short!("BuyoutIn"), vault_id),
+            (buyer, offer_price, deadline),
         );
-
-        vault.active = false;
-        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
-
-        env.events().publish((symbol_short!("merge"), vault_id), ());
     }
 
-    pub fn deposit_rental_income(env: Env, payer: Address, vault_id: u64, amount: i128) {
-        payer.require_auth();
-        let mut vault = Self::require_active_vault(&env, vault_id);
-
-        if amount <= 0 {
-            panic!("invalid_amount");
-        }
-        let token_addr = vault.rental_token.clone().unwrap_or_else(|| panic!("rental_token_not_set"));
-
-        let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&payer, &env.current_contract_address(), &amount);
-
-        vault.acc_rental_per_share += amount
-            .checked_mul(ACC_SCALE)
-            .unwrap_or_else(|| panic!("overflow"))
-            / vault.total_shares;
-
-        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
-    }
-
-    pub fn claim_rental_profit(env: Env, claimer: Address, vault_id: u64) {
-        claimer.require_auth();
-        let vault = Self::require_active_vault(&env, vault_id);
-
-        Self::before_balance_change(&env, vault_id, &claimer);
-
-        let amount = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Claimable(vault_id, claimer.clone()))
-            .unwrap_or(0);
-        if amount <= 0 {
-            panic!("no_claimable");
-        }
-        env.storage()
-            .persistent()
-            .set(&DataKey::Claimable(vault_id, claimer.clone()), &0i128);
-
-        let token_addr = vault.rental_token.unwrap_or_else(|| panic!("rental_token_not_set"));
-        let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&env.current_contract_address(), &claimer, &amount);
-
-        Self::after_balance_change(&env, vault_id, &claimer);
-    }
-
-    pub fn create_proposal_set_rental_token(
-        env: Env,
-        proposer: Address,
-        vault_id: u64,
-        new_rental_token: Address,
-        voting_period_secs: u64,
-    ) -> u64 {
-        proposer.require_auth();
-        let vault = Self::require_active_vault(&env, vault_id);
-
-        if voting_period_secs == 0 {
-            panic!("invalid_voting_period");
-        }
-
-        let proposer_shares = Self::balance(&env, vault_id, &proposer);
-        if proposer_shares <= 0 {
-            panic!("no_shares");
-        }
-
-        let id = Self::next_proposal_id(&env);
-        let start_time = env.ledger().timestamp();
-        let end_time = start_time + voting_period_secs;
-
-        let proposal = Proposal {
-            id,
-            vault_id,
-            proposer,
-            kind: ProposalKind::SetRentalToken,
-            new_rental_token,
-            start_time,
-            end_time,
-            for_votes: 0,
-            against_votes: 0,
-            executed: false,
-        };
-
-        env.storage().persistent().set(&DataKey::Proposal(id), &proposal);
-
-        let _ = vault;
-
-        id
-    }
-
-    pub fn vote(env: Env, voter: Address, proposal_id: u64, support: bool) {
+    /// Cast a weighted vote on the active buyout.  `approve = true` to accept
+    /// the offer, `false` to reject.  Voting power equals the caller's current
+    /// fraction balance.  Each address may vote once per buyout.
+    pub fn vote_buyout(env: Env, voter: Address, vault_id: u64, approve: bool) {
         voter.require_auth();
 
-        let mut proposal: Proposal = env
+        let mut vault: FractionalVault = env
             .storage()
             .persistent()
-            .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal_not_found"));
+            .get(&DataKey::Vault(vault_id))
+            .unwrap_or_else(|| panic!("vault_not_found"));
 
-        let now = env.ledger().timestamp();
-        if now < proposal.start_time {
-            panic!("voting_not_started");
+        if vault.status != VaultStatus::BuyoutPending {
+            panic!("no_active_buyout");
         }
-        if now > proposal.end_time {
+
+        if env.ledger().timestamp() > vault.buyout_deadline {
             panic!("voting_ended");
         }
 
         if env
             .storage()
             .persistent()
-            .has(&DataKey::Voted(proposal_id, voter.clone()))
+            .has(&DataKey::Voted(vault_id, voter.clone()))
         {
             panic!("already_voted");
         }
 
-        let weight = Self::balance(&env, proposal.vault_id, &voter);
+        let weight = Self::get_balance(&env, vault_id, &voter);
         if weight <= 0 {
-            panic!("no_shares");
+            panic!("no_fractions");
         }
 
-        if support {
-            proposal.for_votes += weight;
+        if approve {
+            vault.buyout_votes_for += weight;
         } else {
-            proposal.against_votes += weight;
+            vault.buyout_votes_against += weight;
         }
 
-        env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
+        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
         env.storage()
             .persistent()
-            .set(&DataKey::Voted(proposal_id, voter), &true);
+            .set(&DataKey::Voted(vault_id, voter.clone()), &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Voted(vault_id, voter), 100_000, 500_000);
     }
 
-    pub fn execute_proposal(env: Env, proposal_id: u64) {
-        let mut proposal: Proposal = env
+    /// Settle the buyout after the voting deadline has passed.
+    ///
+    /// * **Vote passes** (for_votes > 50 % of total_fractions): NFT is
+    ///   transferred to the buyer; proceeds remain escrowed for holders to
+    ///   claim via `claim_proceeds`.
+    ///
+    /// * **Vote fails**: offer is refunded to buyer; vault reverts to Active.
+    pub fn settle_buyout(env: Env, vault_id: u64) {
+        let mut vault: FractionalVault = env
             .storage()
             .persistent()
-            .get(&DataKey::Proposal(proposal_id))
-            .unwrap_or_else(|| panic!("proposal_not_found"));
+            .get(&DataKey::Vault(vault_id))
+            .unwrap_or_else(|| panic!("vault_not_found"));
 
-        if proposal.executed {
-            panic!("already_executed");
+        if vault.status != VaultStatus::BuyoutPending {
+            panic!("no_active_buyout");
         }
 
-        let now = env.ledger().timestamp();
-        if now <= proposal.end_time {
+        if env.ledger().timestamp() <= vault.buyout_deadline {
             panic!("voting_not_ended");
         }
 
-        if proposal.for_votes <= proposal.against_votes {
-            panic!("proposal_defeated");
+        let buyer = vault.buyout_buyer.clone().unwrap();
+
+        // >50 % of the total fraction supply must have voted in favour.
+        let approved = vault.buyout_votes_for * 2 > vault.total_fractions;
+
+        if approved {
+            // Transfer the locked NFT to the buyer.
+            let transfer_args =
+                (env.current_contract_address(), buyer.clone(), vault.nft_id).into_val(&env);
+            env.invoke_contract::<()>(
+                &vault.nft_contract,
+                &Symbol::new(&env, "transfer"),
+                transfer_args,
+            );
+
+            vault.status = VaultStatus::Completed;
+            env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+
+            // Event: BuyoutCompleted
+            env.events().publish(
+                (symbol_short!("BuyoutOk"), vault_id),
+                (buyer, vault.buyout_offer_price),
+            );
+        } else {
+            // Refund the escrowed offer to the buyer.
+            let token_client = token::Client::new(&env, &vault.payment_token);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &buyer,
+                &vault.buyout_offer_price,
+            );
+
+            // Reset buyout state; vault returns to Active.
+            vault.status = VaultStatus::Active;
+            vault.buyout_buyer = None;
+            vault.buyout_offer_price = 0;
+            vault.buyout_deadline = 0;
+            vault.buyout_votes_for = 0;
+            vault.buyout_votes_against = 0;
+            env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+
+            // Event: BuyoutRejected
+            env.events().publish((symbol_short!("BuyoutNo"), vault_id), ());
         }
-
-        let mut vault: Vault = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Vault(proposal.vault_id))
-            .unwrap_or_else(|| panic!("vault_not_found"));
-
-        if !vault.active {
-            panic!("vault_inactive");
-        }
-
-        match proposal.kind {
-            ProposalKind::SetRentalToken => {
-                vault.rental_token = Some(proposal.new_rental_token.clone());
-                env.storage().persistent().set(&DataKey::Vault(vault.id), &vault);
-            }
-        }
-
-        proposal.executed = true;
-        env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
     }
 
+    /// After a completed buyout, fraction holders call this to redeem their
+    /// pro-rata share of the escrowed proceeds.
+    pub fn claim_proceeds(env: Env, holder: Address, vault_id: u64) {
+        holder.require_auth();
+
+        let vault: FractionalVault = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vault(vault_id))
+            .unwrap_or_else(|| panic!("vault_not_found"));
+
+        if vault.status != VaultStatus::Completed {
+            panic!("buyout_not_completed");
+        }
+
+        let fractions = Self::get_balance(&env, vault_id, &holder);
+        if fractions <= 0 {
+            panic!("no_fractions");
+        }
+
+        // Proportional share of the total offer.
+        let payout = vault
+            .buyout_offer_price
+            .checked_mul(fractions)
+            .unwrap_or_else(|| panic!("overflow"))
+            / vault.total_fractions;
+
+        // Burn the holder's fractions to prevent double-claiming.
+        Self::set_balance(&env, vault_id, &holder, 0);
+
+        let token_client = token::Client::new(&env, &vault.payment_token);
+        token_client.transfer(&env.current_contract_address(), &holder, &payout);
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Return the full vault state (lock status, fraction supply, buyout info).
+    pub fn get_vault(env: Env, vault_id: u64) -> Option<FractionalVault> {
+        env.storage().persistent().get(&DataKey::Vault(vault_id))
+    }
+
+    /// Return the fraction balance of `owner` in `vault_id`.
+    pub fn balance_of(env: Env, vault_id: u64, owner: Address) -> i128 {
+        Self::get_balance(&env, vault_id, &owner)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
     fn next_vault_id(env: &Env) -> u64 {
-        let mut id: u64 = env.storage().instance().get(&DataKey::VaultCount).unwrap_or(0);
+        let mut id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VaultCount)
+            .unwrap_or(0);
         id += 1;
         env.storage().instance().set(&DataKey::VaultCount, &id);
         id
     }
 
-    fn next_listing_id(env: &Env) -> u64 {
-        let mut id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::ListingCount)
-            .unwrap_or(0);
-        id += 1;
-        env.storage().instance().set(&DataKey::ListingCount, &id);
-        id
-    }
-
-    fn next_proposal_id(env: &Env) -> u64 {
-        let mut id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::ProposalCount)
-            .unwrap_or(0);
-        id += 1;
-        env.storage().instance().set(&DataKey::ProposalCount, &id);
-        id
-    }
-
-    fn require_active_vault(env: &Env, vault_id: u64) -> Vault {
-        let vault: Vault = env
+    fn require_active_vault(env: &Env, vault_id: u64) -> FractionalVault {
+        let vault: FractionalVault = env
             .storage()
             .persistent()
             .get(&DataKey::Vault(vault_id))
             .unwrap_or_else(|| panic!("vault_not_found"));
-        if !vault.active {
-            panic!("vault_inactive");
+        if vault.status != VaultStatus::Active {
+            panic!("vault_not_active");
         }
         vault
     }
 
-    fn balance(env: &Env, vault_id: u64, owner: &Address) -> i128 {
+    fn get_balance(env: &Env, vault_id: u64, owner: &Address) -> i128 {
         env.storage()
             .persistent()
             .get(&DataKey::Balance(vault_id, owner.clone()))
@@ -776,103 +469,9 @@ impl FractionalNftContract {
         env.storage()
             .persistent()
             .set(&DataKey::Balance(vault_id, owner.clone()), &amount);
-    }
-
-    fn set_reward_debt(env: &Env, vault_id: u64, owner: &Address, amount: i128) {
         env.storage()
             .persistent()
-            .set(&DataKey::RewardDebt(vault_id, owner.clone()), &amount);
-    }
-
-    fn before_balance_change(env: &Env, vault_id: u64, owner: &Address) {
-        if let Some(vault) = env.storage().persistent().get::<DataKey, Vault>(&DataKey::Vault(vault_id)) {
-            if !vault.active {
-                return;
-            }
-            let bal = Self::balance(env, vault_id, owner);
-            let debt = env
-                .storage()
-                .persistent()
-                .get(&DataKey::RewardDebt(vault_id, owner.clone()))
-                .unwrap_or(0);
-
-            let accumulated = bal
-                .checked_mul(vault.acc_rental_per_share)
-                .unwrap_or_else(|| panic!("overflow"))
-                / ACC_SCALE;
-
-            let pending = accumulated - debt;
-            if pending > 0 {
-                let key = DataKey::Claimable(vault_id, owner.clone());
-                let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-                env.storage().persistent().set(&key, &(current + pending));
-            }
-        }
-    }
-
-    fn after_balance_change(env: &Env, vault_id: u64, owner: &Address) {
-        if let Some(vault) = env.storage().persistent().get::<DataKey, Vault>(&DataKey::Vault(vault_id)) {
-            if !vault.active {
-                return;
-            }
-            let bal = Self::balance(env, vault_id, owner);
-            let new_debt = bal
-                .checked_mul(vault.acc_rental_per_share)
-                .unwrap_or_else(|| panic!("overflow"))
-                / ACC_SCALE;
-            Self::set_reward_debt(env, vault_id, owner, new_debt);
-        }
-    }
-
-    fn transfer_shares_internal(env: &Env, vault_id: u64, from: &Address, to: &Address, amount: i128) {
-        if amount <= 0 {
-            panic!("invalid_amount");
-        }
-
-        Self::before_balance_change(env, vault_id, from);
-        Self::before_balance_change(env, vault_id, to);
-
-        let from_bal = Self::balance(env, vault_id, from);
-        if from_bal < amount {
-            panic!("insufficient_balance");
-        }
-        let to_bal = Self::balance(env, vault_id, to);
-
-        Self::set_balance(env, vault_id, from, from_bal - amount);
-        Self::set_balance(env, vault_id, to, to_bal + amount);
-
-        Self::enforce_min_threshold(env, vault_id, from);
-        Self::enforce_min_threshold(env, vault_id, to);
-
-        Self::after_balance_change(env, vault_id, from);
-        Self::after_balance_change(env, vault_id, to);
-    }
-
-    fn enforce_min_threshold(env: &Env, vault_id: u64, owner: &Address) {
-        let vault: Vault = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Vault(vault_id))
-            .unwrap_or_else(|| panic!("vault_not_found"));
-
-        if vault.min_ownership_bps == 0 {
-            return;
-        }
-
-        let bal = Self::balance(env, vault_id, owner);
-        if bal == 0 {
-            return;
-        }
-
-        let min_shares = (vault.total_shares
-            .checked_mul(vault.min_ownership_bps as i128)
-            .unwrap_or_else(|| panic!("overflow"))
-            + (BPS_DENOMINATOR - 1))
-            / BPS_DENOMINATOR;
-
-        if bal < min_shares {
-            panic!("below_min_ownership_threshold");
-        }
+            .extend_ttl(&DataKey::Balance(vault_id, owner.clone()), 100_000, 500_000);
     }
 }
 

--- a/contracts/fractional_nft/src/test.rs
+++ b/contracts/fractional_nft/src/test.rs
@@ -1,9 +1,16 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{contract, contractimpl, testutils::{Address as _, Ledger}, token, Address, Env, String};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
 
-// Mock NFT contract for testing fractional_nft
+// ---------------------------------------------------------------------------
+// Mock NFT contract
+// ---------------------------------------------------------------------------
+
 #[contract]
 pub struct MockNFT;
 
@@ -18,7 +25,8 @@ impl MockNFT {
 
     pub fn transfer(env: Env, from: Address, to: Address, token_id: u32) {
         from.require_auth();
-        let current_owner: Address = env.storage()
+        let current_owner: Address = env
+            .storage()
             .persistent()
             .get(&token_id)
             .unwrap_or_else(|| panic!("token_not_found"));
@@ -33,6 +41,10 @@ impl MockNFT {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
 fn setup_token<'a>(
     env: &'a Env,
     admin: &'a Address,
@@ -40,319 +52,406 @@ fn setup_token<'a>(
     let token_id = env
         .register_stellar_asset_contract_v2(admin.clone())
         .address();
-    let token_client = token::Client::new(env, &token_id);
-    let token_admin_client = token::StellarAssetClient::new(env, &token_id);
-    (token_id, token_client, token_admin_client)
+    let client = token::Client::new(env, &token_id);
+    let admin_client = token::StellarAssetClient::new(env, &token_id);
+    (token_id, client, admin_client)
 }
 
-fn setup_mock_nft<'a>(env: &'a Env) -> (Address, MockNFTClient<'a>) {
-    let nft_id = env.register_contract(None, MockNFT);
-    let client = MockNFTClient::new(env, &nft_id);
-    (nft_id, client)
+fn setup_nft(env: &Env) -> (Address, MockNFTClient) {
+    let nft_addr = env.register_contract(None, MockNFT);
+    let client = MockNFTClient::new(env, &nft_addr);
+    (nft_addr, client)
 }
 
+fn setup_vault(env: &Env) -> (Address, FractionalNftContractClient) {
+    let addr = env.register_contract(None, FractionalNftContract);
+    let client = FractionalNftContractClient::new(env, &addr);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (addr, client)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// fractionalize locks the NFT and credits all fractions to the owner.
 #[test]
-fn test_fractionalize_and_transfer_shares() {
+fn test_fractionalize_basic() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let (payment_token_id, _, _) = setup_token(&env, &admin);
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (vault_addr, vault) = setup_vault(&env);
+
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
+    );
+
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.total_fractions, 1_000);
+    assert_eq!(state.buyout_price, 10_000);
+    assert_eq!(state.status, VaultStatus::Active);
+    assert_eq!(state.fraction_token, vault_addr);
+
+    // All fractions credited to owner.
+    assert_eq!(vault.balance_of(&vid, &owner), 1_000);
+
+    // NFT is now held by the vault contract.
+    assert_eq!(nft.owner_of(&1u32), vault_addr);
+}
+
+/// buy_fraction transfers fractions from owner to buyer, charging the correct
+/// pro-rata price.
+#[test]
+fn test_buy_fraction() {
+    let env = Env::default();
+    env.mock_all_auths();
 
     let admin = Address::generate(&env);
     let owner = Address::generate(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &owner);
+    let buyer = Address::generate(&env);
 
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    let (payment_token_id, payment_token, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &5_000i128);
 
-    let vault_id = client.fractionalize(
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+
+    // 1000 fractions, buyout_price = 10_000  ⟹  price_per_fraction = 10
+    let vid = vault.fractionalize(
         &owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &None,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
     );
 
-    assert_eq!(client.get_vault(&vault_id).unwrap().total_shares, 100);
-    assert_eq!(client.balance_of(&vault_id, &owner), 100);
+    // Buyer purchases 100 fractions at 10 tokens each = 1_000 tokens.
+    vault.buy_fraction(&buyer, &vid, &100i128);
 
+    assert_eq!(vault.balance_of(&vid, &buyer), 100);
+    assert_eq!(vault.balance_of(&vid, &owner), 900);
+    // Owner received 1_000 tokens.
+    assert_eq!(payment_token.balance(&owner), 1_000);
+    // Buyer spent 1_000 tokens.
+    assert_eq!(payment_token.balance(&buyer), 4_000);
+}
+
+/// transfer_fraction moves fractions between holders without payment.
+#[test]
+fn test_transfer_fraction() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
     let alice = Address::generate(&env);
-    client.transfer_shares(&vault_id, &owner, &alice, &25i128);
 
-    assert_eq!(client.balance_of(&vault_id, &owner), 75);
-    assert_eq!(client.balance_of(&vault_id, &alice), 25);
+    let (payment_token_id, _, _) = setup_token(&env, &admin);
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &100i128,
+        &1_000i128,
+        &payment_token_id,
+    );
+
+    vault.transfer_fraction(&owner, &vid, &alice, &30i128);
+
+    assert_eq!(vault.balance_of(&vid, &owner), 70);
+    assert_eq!(vault.balance_of(&vid, &alice), 30);
 }
 
+/// initiate_buyout requires offer_price >= buyout_price.
 #[test]
-#[should_panic(expected = "below_min_ownership_threshold")]
-fn test_minimum_ownership_threshold_enforced() {
+#[should_panic(expected = "offer_below_buyout_price")]
+fn test_initiate_buyout_low_offer() {
     let env = Env::default();
     env.mock_all_auths();
-
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
 
     let admin = Address::generate(&env);
     let owner = Address::generate(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &owner);
+    let buyer = Address::generate(&env);
 
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    let (payment_token_id, _, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &5_000i128);
 
-    // total_shares=100, min_ownership_bps=1000 => min_shares=10
-    let vault_id = client.fractionalize(
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+    let vid = vault.fractionalize(
         &owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &1000u32,
-        &None,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
     );
 
-    let bob = Address::generate(&env);
-    // This would leave bob with 5 shares (below 10) => should panic.
-    client.transfer_shares(&vault_id, &owner, &bob, &5i128);
+    // Offer 5_000 but buyout_price is 10_000 → should panic.
+    vault.initiate_buyout(&buyer, &vid, &5_000i128);
 }
 
+/// Full happy-path: buyout passes, NFT transfers, holders claim proceeds.
 #[test]
-fn test_share_trading_listing_buy_and_cancel() {
+fn test_buyout_passes_and_proceeds_claimed() {
     let env = Env::default();
     env.mock_all_auths();
 
     let admin = Address::generate(&env);
-    let seller = Address::generate(&env);
-    let buyer = Address::generate(&env);
-
-    let (payment_token_id, payment_token, payment_admin) = setup_token(&env, &admin);
-    payment_admin.mint(&buyer, &1_000);
-
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &seller);
-
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-
-    let vault_id = client.fractionalize(
-        &seller,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &None,
-    );
-
-    let listing_id = client.create_listing(
-        &seller,
-        &vault_id,
-        &20i128,
-        &payment_token_id,
-        &2i128,
-        &None,
-    );
-
-    assert_eq!(client.balance_of(&vault_id, &seller), 80);
-    assert_eq!(client.balance_of(&vault_id, &contract_id), 20);
-
-    client.buy_listing(&buyer, &listing_id);
-
-    assert_eq!(client.balance_of(&vault_id, &buyer), 20);
-    assert_eq!(client.balance_of(&vault_id, &contract_id), 0);
-
-    // Buyer paid seller 40 tokens.
-    assert_eq!(payment_token.balance(&buyer), 960);
-    assert_eq!(payment_token.balance(&seller), 40);
-
-    // Create another listing and cancel it.
-    let listing_id2 = client.create_listing(
-        &seller,
-        &vault_id,
-        &10i128,
-        &payment_token_id,
-        &1i128,
-        &None,
-    );
-    assert_eq!(client.balance_of(&vault_id, &contract_id), 10);
-
-    client.cancel_listing(&seller, &listing_id2);
-    assert_eq!(client.balance_of(&vault_id, &contract_id), 0);
-    assert_eq!(client.balance_of(&vault_id, &seller), 80);
-}
-
-#[test]
-fn test_buyout_tender_and_reclaim() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let buyer = Address::generate(&env);
+    let owner = Address::generate(&env);
     let holder = Address::generate(&env);
+    let buyer = Address::generate(&env);
 
     let (payment_token_id, payment_token, payment_admin) = setup_token(&env, &admin);
-    payment_admin.mint(&buyer, &10_000);
+    payment_admin.mint(&buyer, &20_000i128);
 
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
 
-    let original_owner = Address::generate(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &original_owner);
+    let (vault_addr, vault) = setup_vault(&env);
 
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-
-    let vault_id = client.fractionalize(
-        &original_owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &None,
+    // 1_000 fractions, buyout_price = 10_000.
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
     );
 
-    // Move some shares to holder.
-    client.transfer_shares(&vault_id, &original_owner, &holder, &30i128);
+    // Give holder 400 fractions (owner keeps 600).
+    vault.transfer_fraction(&owner, &vid, &holder, &400i128);
+
+    assert_eq!(vault.balance_of(&vid, &owner), 600);
+    assert_eq!(vault.balance_of(&vid, &holder), 400);
+
+    // Buyer initiates buyout at 12_000 (≥ 10_000).
+    env.ledger().set_timestamp(1_000);
+    vault.initiate_buyout(&buyer, &vid, &12_000i128);
+
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.status, VaultStatus::BuyoutPending);
+
+    // Both owner (600) and holder (400) vote in favour → 1_000 / 1_000 = 100 %.
+    vault.vote_buyout(&owner, &vid, &true);
+    vault.vote_buyout(&holder, &vid, &true);
+
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.buyout_votes_for, 1_000);
+    assert_eq!(state.buyout_votes_against, 0);
+
+    // Advance past deadline.
+    env.ledger().set_timestamp(1_000 + VOTING_PERIOD_SECS + 1);
+    vault.settle_buyout(&vid);
+
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.status, VaultStatus::Completed);
+
+    // NFT is now owned by buyer.
+    assert_eq!(nft.owner_of(&1u32), buyer);
+
+    // Holders claim their proportional proceeds from the 12_000 offer.
+    // owner: 600/1000 * 12_000 = 7_200
+    // holder: 400/1000 * 12_000 = 4_800
+    vault.claim_proceeds(&owner, &vid);
+    vault.claim_proceeds(&holder, &vid);
+
+    assert_eq!(payment_token.balance(&owner), 7_200);
+    assert_eq!(payment_token.balance(&holder), 4_800);
+
+    // Vault contract holds nothing (fully distributed).
+    assert_eq!(payment_token.balance(&vault_addr), 0);
+
+    // Fractions burned after claim.
+    assert_eq!(vault.balance_of(&vid, &owner), 0);
+    assert_eq!(vault.balance_of(&vid, &holder), 0);
+}
+
+/// Buyout fails when approval is below 50 % of total fractions; offer refunded.
+#[test]
+fn test_buyout_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let (payment_token_id, payment_token, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &15_000i128);
+
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+
+    // 1_000 fractions; owner keeps 600, holder gets 400.
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
+    );
+    vault.transfer_fraction(&owner, &vid, &holder, &400i128);
+
+    env.ledger().set_timestamp(1_000);
+    vault.initiate_buyout(&buyer, &vid, &12_000i128);
+
+    // Only holder (400 fractions) votes against → 0 for, 400 against.
+    // 0 * 2 <= 1_000 → rejected.
+    vault.vote_buyout(&holder, &vid, &false);
+
+    env.ledger().set_timestamp(1_000 + VOTING_PERIOD_SECS + 1);
+    vault.settle_buyout(&vid);
+
+    let state = vault.get_vault(&vid).unwrap();
+    // Vault reverts to Active after rejection.
+    assert_eq!(state.status, VaultStatus::Active);
+
+    // NFT still locked in vault.
+    let (vault_addr, _) = setup_vault(&env); // re-derive for address
+    // (We compare against the vault client's address)
+    // Instead, directly check buyer does NOT own NFT.
+    assert_ne!(nft.owner_of(&1u32), buyer);
+
+    // Buyer was refunded the full 12_000.
+    assert_eq!(payment_token.balance(&buyer), 15_000);
+}
+
+/// A fraction holder cannot vote twice on the same buyout.
+#[test]
+#[should_panic(expected = "already_voted")]
+fn test_double_vote_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let (payment_token_id, _, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &20_000i128);
+
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
+    );
+
+    env.ledger().set_timestamp(1_000);
+    vault.initiate_buyout(&buyer, &vid, &12_000i128);
+
+    vault.vote_buyout(&owner, &vid, &true);
+    // Second vote from the same address → panic.
+    vault.vote_buyout(&owner, &vid, &false);
+}
+
+/// Addresses without fractions cannot vote.
+#[test]
+#[should_panic(expected = "no_fractions")]
+fn test_non_holder_cannot_vote() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let (payment_token_id, _, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &20_000i128);
+
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &1_000i128,
+        &10_000i128,
+        &payment_token_id,
+    );
+
+    env.ledger().set_timestamp(1_000);
+    vault.initiate_buyout(&buyer, &vid, &12_000i128);
+
+    // Stranger holds 0 fractions → should panic.
+    vault.vote_buyout(&stranger, &vid, &true);
+}
+
+/// get_vault returns the NFT lock status, fraction supply, and buyout state.
+#[test]
+fn test_get_vault_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let (payment_token_id, _, payment_admin) = setup_token(&env, &admin);
+    payment_admin.mint(&buyer, &20_000i128);
+
+    let (nft_addr, nft) = setup_nft(&env);
+    nft.set_owner(&1u32, &owner);
+
+    let (_, vault) = setup_vault(&env);
+    let vid = vault.fractionalize(
+        &owner,
+        &nft_addr,
+        &1u32,
+        &500i128,
+        &5_000i128,
+        &payment_token_id,
+    );
+
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.nft_id, 1);
+    assert_eq!(state.total_fractions, 500);
+    assert_eq!(state.buyout_price, 5_000);
+    assert_eq!(state.status, VaultStatus::Active);
+    assert!(state.buyout_buyer.is_none());
 
     env.ledger().set_timestamp(100);
-    client.start_buyout(&buyer, &vault_id, &payment_token_id, &1_000i128, &200u64);
+    vault.initiate_buyout(&buyer, &vid, &6_000i128);
 
-    // Holder tenders 10 shares => gets 1000 * 10 / 100 = 100.
-    client.tender_shares(&holder, &vault_id, &10i128);
-    assert_eq!(payment_token.balance(&holder), 100);
-    assert_eq!(client.balance_of(&vault_id, &buyer), 10);
-
-    // After end_time, buyer can reclaim remaining escrow.
-    env.ledger().set_timestamp(201);
-    let buyer_before = payment_token.balance(&buyer);
-    client.reclaim_buyout_escrow(&buyer, &vault_id);
-    let buyer_after = payment_token.balance(&buyer);
-    assert!(buyer_after > buyer_before);
-}
-
-#[test]
-fn test_profit_sharing_from_rentals_and_claim() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let payer = Address::generate(&env);
-    let owner = Address::generate(&env);
-    let other = Address::generate(&env);
-
-    let (rental_token_id, rental_token, rental_admin) = setup_token(&env, &admin);
-    rental_admin.mint(&payer, &1_000);
-
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &owner);
-
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-
-    let vault_id = client.fractionalize(
-        &owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &Some(rental_token_id.clone()),
-    );
-
-    // Transfer 40 shares to other.
-    client.transfer_shares(&vault_id, &owner, &other, &40i128);
-
-    client.deposit_rental_income(&payer, &vault_id, &500i128);
-
-    // Owner has 60%, other has 40%.
-    client.claim_rental_profit(&owner, &vault_id);
-    client.claim_rental_profit(&other, &vault_id);
-
-    assert_eq!(rental_token.balance(&owner), 300);
-    assert_eq!(rental_token.balance(&other), 200);
-}
-
-#[test]
-fn test_voting_set_rental_token() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let owner = Address::generate(&env);
-    let voter2 = Address::generate(&env);
-
-    let (new_rental_token_id, _, _) = setup_token(&env, &admin);
-
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &owner);
-
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-
-    let vault_id = client.fractionalize(
-        &owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &None,
-    );
-
-    client.transfer_shares(&vault_id, &owner, &voter2, &30i128);
-
-    env.ledger().set_timestamp(100);
-    let proposal_id = client.create_proposal_set_rental_token(
-        &owner,
-        &vault_id,
-        &new_rental_token_id,
-        &50u64,
-    );
-
-    client.vote(&owner, &proposal_id, &true);
-    client.vote(&voter2, &proposal_id, &true);
-
-    env.ledger().set_timestamp(151);
-    client.execute_proposal(&proposal_id);
-
-    assert_eq!(client.get_vault(&vault_id).unwrap().rental_token, Some(new_rental_token_id));
-}
-
-#[test]
-fn test_recombine_merge_fractions() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let admin = Address::generate(&env);
-    let owner = Address::generate(&env);
-    let receiver = Address::generate(&env);
-
-    let (nft_contract_id, nft) = setup_mock_nft(&env);
-    let token_id = 1u32;
-    nft.set_owner(&token_id, &owner);
-
-    let contract_id = env.register_contract(None, FractionalNftContract);
-    let client = FractionalNftContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
-
-    let vault_id = client.fractionalize(
-        &owner,
-        &nft_contract_id,
-        &token_id,
-        &100i128,
-        &0u32,
-        &None,
-    );
-
-    // Owner already holds 100 shares.
-    client.recombine(&owner, &vault_id, &receiver);
-
-    assert_eq!(nft.owner_of(&token_id), receiver);
-    assert_eq!(client.get_vault(&vault_id).unwrap().active, false);
+    let state = vault.get_vault(&vid).unwrap();
+    assert_eq!(state.status, VaultStatus::BuyoutPending);
+    assert_eq!(state.buyout_offer_price, 6_000);
+    assert_eq!(state.buyout_buyer, Some(buyer.clone()));
+    assert_eq!(state.buyout_deadline, 100 + VOTING_PERIOD_SECS);
 }


### PR DESCRIPTION
Description:

  Rewrites the fractional_nft contract to support a complete fractionalization lifecycle for rare achievement NFTs.        

  What's included:

  - FractionalVault struct with nft_id, total_fractions, fraction_token, status, buyout_price, and vote tracking fields    
  - fractionalize — locks NFT into vault, mints all fraction tokens to the original owner
  - buy_fraction — lets players purchase fractions from the owner at the pro-rata price (buyout_price / total_fractions)   
  - transfer_fraction — peer-to-peer fraction transfer
  - initiate_buyout — buyer deposits an offer (≥ buyout_price) into escrow and opens a 7-day voting window
  - vote_buyout — fraction holders cast weighted votes; one vote per address per buyout
  - settle_buyout — resolves the vote after the deadline: if >50% of total fractions approved, transfers the NFT to the    
  buyer; otherwise refunds the buyer and resets the vault to Active
  - claim_proceeds — fraction holders redeem their pro-rata share of the buyout proceeds after a completed buyout
  - get_vault — returns full vault state (lock status, fraction supply, buyout info)
  - Events: NFTFrac (fractionalized), BuyoutIn (initiated), BuyoutOk (completed), BuyoutNo (rejected)
  - 8 unit tests covering the full happy path, rejection path, double-vote guard, non-holder vote guard, and state queries 

closes #131 