### PR TITLE
feat: add NFT bundle and pack contract (#147)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
   "contracts/tournament_prize_pool",
   "contracts/loyalty_points",
   "contracts/nft_upgrade",
+  "contracts/nft_bundle",
 ]
 
 [workspace.dependencies]

--- a/contracts/nft_bundle/Cargo.toml
+++ b/contracts/nft_bundle/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nft-bundle"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/nft_bundle/src/lib.rs
+++ b/contracts/nft_bundle/src/lib.rs
@@ -1,0 +1,430 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, vec, Address, Bytes, Env, IntoVal,
+    Vec,
+};
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+/// Whether the pack contents are predetermined or drawn at random.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PackType {
+    Fixed = 0,
+    Blind = 1,
+}
+
+/// Status of a bundle.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BundleStatus {
+    Active = 0,
+    Closed = 1,
+    Cancelled = 2,
+}
+
+/// A single NFT token reference: the NFT contract address + token id.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenRef {
+    pub nft_contract: Address,
+    pub token_id: u32,
+}
+
+/// Core bundle data stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NftBundle {
+    pub id: u64,
+    pub creator: Address,
+    pub pack_type: PackType,
+    /// Remaining NFTs available for purchase (pool shrinks as packs are sold).
+    pub nft_pool: Vec<TokenRef>,
+    /// How many NFTs are delivered per pack purchase.
+    pub nfts_per_pack: u32,
+    /// Price in the payment token per pack.
+    pub price: i128,
+    /// Payment token address.
+    pub payment_token: Address,
+    /// Packs still available.
+    pub packs_remaining: u32,
+    pub status: BundleStatus,
+}
+
+#[contracttype]
+pub enum DataKey {
+    BundleCount,
+    Bundle(u64),
+}
+
+// ─────────────────────────────────────────────
+// Contract
+// ─────────────────────────────────────────────
+
+#[contract]
+pub struct NftBundleContract;
+
+#[contractimpl]
+impl NftBundleContract {
+    // ── create_bundle ────────────────────────────────────────────────────────
+
+    /// Creator locks NFTs into the contract and defines the bundle.
+    ///
+    /// * `nft_pool`      – list of NFTs to lock; must be divisible by `nfts_per_pack`
+    /// * `nfts_per_pack` – how many NFTs a buyer receives per pack
+    /// * `price`         – payment token amount per pack
+    /// * `payment_token` – token used for payment
+    pub fn create_bundle(
+        env: Env,
+        creator: Address,
+        pack_type: PackType,
+        nft_pool: Vec<TokenRef>,
+        nfts_per_pack: u32,
+        price: i128,
+        payment_token: Address,
+    ) -> u64 {
+        creator.require_auth();
+
+        let pool_len = nft_pool.len();
+        if pool_len == 0 {
+            panic!("empty_pool");
+        }
+        if nfts_per_pack == 0 {
+            panic!("zero_nfts_per_pack");
+        }
+        if pool_len % nfts_per_pack != 0 {
+            panic!("pool_not_divisible_by_pack_size");
+        }
+        if price <= 0 {
+            panic!("invalid_price");
+        }
+
+        let total_packs = pool_len / nfts_per_pack;
+
+        // Transfer every NFT from creator into this contract.
+        for token_ref in nft_pool.iter() {
+            Self::transfer_nft(
+                &env,
+                &token_ref.nft_contract,
+                &creator,
+                &env.current_contract_address(),
+                token_ref.token_id,
+            );
+        }
+
+        let id = Self::next_bundle_id(&env);
+
+        let bundle = NftBundle {
+            id,
+            creator: creator.clone(),
+            pack_type,
+            nft_pool,
+            nfts_per_pack,
+            price,
+            payment_token,
+            packs_remaining: total_packs,
+            status: BundleStatus::Active,
+        };
+
+        env.storage().persistent().set(&DataKey::Bundle(id), &bundle);
+
+        env.events().publish(
+            (symbol_short!("BndlCrtd"), id),
+            (creator, pack_type as u32, total_packs, price),
+        );
+
+        id
+    }
+
+    // ── purchase_pack ────────────────────────────────────────────────────────
+
+    /// Buyer pays `price` and receives `nfts_per_pack` NFTs.
+    ///
+    /// Fixed packs take the first N NFTs from the pool (deterministic).
+    /// Blind packs draw N NFTs pseudo-randomly using ledger entropy.
+    pub fn purchase_pack(env: Env, buyer: Address, bundle_id: u64) -> Vec<TokenRef> {
+        buyer.require_auth();
+
+        let mut bundle = Self::require_active_bundle(&env, bundle_id);
+
+        if bundle.packs_remaining == 0 {
+            panic!("no_packs_remaining");
+        }
+
+        // Collect payment.
+        token::Client::new(&env, &bundle.payment_token).transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &bundle.price,
+        );
+
+        let n = bundle.nfts_per_pack as usize;
+        let received: Vec<TokenRef>;
+
+        match bundle.pack_type {
+            PackType::Fixed => {
+                // Take the first N from the pool.
+                received = Self::take_first_n(&env, &mut bundle.nft_pool, n);
+            }
+            PackType::Blind => {
+                // Pseudo-random draw using ledger sequence + buyer address.
+                received = Self::blind_draw(&env, &mut bundle.nft_pool, n, &buyer);
+            }
+        }
+
+        // Transfer each drawn NFT to the buyer.
+        for token_ref in received.iter() {
+            Self::transfer_nft(
+                &env,
+                &token_ref.nft_contract,
+                &env.current_contract_address(),
+                &buyer,
+                token_ref.token_id,
+            );
+        }
+
+        bundle.packs_remaining -= 1;
+
+        // Auto-close when the last pack is sold.
+        if bundle.packs_remaining == 0 {
+            bundle.status = BundleStatus::Closed;
+            env.events().publish(
+                (symbol_short!("BndlClsd"), bundle_id),
+                (bundle_id,),
+            );
+        }
+
+        env.storage().persistent().set(&DataKey::Bundle(bundle_id), &bundle);
+
+        // Emit PackPurchased event.
+        env.events().publish(
+            (symbol_short!("PckPrchsd"), bundle_id),
+            (buyer, bundle_id, received.clone()),
+        );
+
+        received
+    }
+
+    // ── cancel_bundle ────────────────────────────────────────────────────────
+
+    /// Creator cancels an active bundle before it sells out.
+    pub fn cancel_bundle(env: Env, creator: Address, bundle_id: u64) {
+        creator.require_auth();
+
+        let mut bundle: NftBundle = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Bundle(bundle_id))
+            .unwrap_or_else(|| panic!("bundle_not_found"));
+
+        if bundle.creator != creator {
+            panic!("not_creator");
+        }
+        if bundle.status != BundleStatus::Active {
+            panic!("bundle_not_active");
+        }
+
+        bundle.status = BundleStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Bundle(bundle_id), &bundle);
+
+        env.events().publish(
+            (symbol_short!("BndlClsd"), bundle_id),
+            (bundle_id,),
+        );
+    }
+
+    // ── withdraw_unsold ──────────────────────────────────────────────────────
+
+    /// Creator reclaims unsold NFTs after the bundle is closed or cancelled.
+    pub fn withdraw_unsold(env: Env, creator: Address, bundle_id: u64) {
+        creator.require_auth();
+
+        let mut bundle: NftBundle = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Bundle(bundle_id))
+            .unwrap_or_else(|| panic!("bundle_not_found"));
+
+        if bundle.creator != creator {
+            panic!("not_creator");
+        }
+        if bundle.status == BundleStatus::Active {
+            panic!("bundle_still_active");
+        }
+        if bundle.nft_pool.is_empty() {
+            panic!("nothing_to_withdraw");
+        }
+
+        // Return every remaining NFT to the creator.
+        let remaining = bundle.nft_pool.clone();
+        for token_ref in remaining.iter() {
+            Self::transfer_nft(
+                &env,
+                &token_ref.nft_contract,
+                &env.current_contract_address(),
+                &creator,
+                token_ref.token_id,
+            );
+        }
+
+        bundle.nft_pool = Vec::new(&env);
+        env.storage().persistent().set(&DataKey::Bundle(bundle_id), &bundle);
+    }
+
+    // ── withdraw_proceeds ────────────────────────────────────────────────────
+
+    /// Creator withdraws accumulated payment token proceeds.
+    pub fn withdraw_proceeds(env: Env, creator: Address, bundle_id: u64) {
+        creator.require_auth();
+
+        let bundle: NftBundle = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Bundle(bundle_id))
+            .unwrap_or_else(|| panic!("bundle_not_found"));
+
+        if bundle.creator != creator {
+            panic!("not_creator");
+        }
+
+        let token_client = token::Client::new(&env, &bundle.payment_token);
+        let balance = token_client.balance(&env.current_contract_address());
+        if balance <= 0 {
+            panic!("no_proceeds");
+        }
+
+        token_client.transfer(&env.current_contract_address(), &creator, &balance);
+    }
+
+    // ── get_bundle ───────────────────────────────────────────────────────────
+
+    /// Returns pack type, price, packs remaining, and pool size.
+    pub fn get_bundle(env: Env, bundle_id: u64) -> Option<NftBundle> {
+        env.storage().persistent().get(&DataKey::Bundle(bundle_id))
+    }
+
+    // ─────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────
+
+    fn next_bundle_id(env: &Env) -> u64 {
+        let mut id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BundleCount)
+            .unwrap_or(0);
+        id += 1;
+        env.storage().instance().set(&DataKey::BundleCount, &id);
+        id
+    }
+
+    fn require_active_bundle(env: &Env, bundle_id: u64) -> NftBundle {
+        let bundle: NftBundle = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Bundle(bundle_id))
+            .unwrap_or_else(|| panic!("bundle_not_found"));
+        if bundle.status != BundleStatus::Active {
+            panic!("bundle_not_active");
+        }
+        bundle
+    }
+
+    /// Remove and return the first `n` items from `pool`.
+    fn take_first_n(env: &Env, pool: &mut Vec<TokenRef>, n: usize) -> Vec<TokenRef> {
+        let mut out: Vec<TokenRef> = Vec::new(env);
+        for _ in 0..n {
+            out.push_back(pool.get(0).unwrap());
+            pool.remove(0);
+        }
+        out
+    }
+
+    /// Pseudo-random draw of `n` distinct items from `pool`.
+    ///
+    /// Entropy: SHA-256( ledger_sequence_bytes ++ buyer_address_bytes )
+    fn blind_draw(
+        env: &Env,
+        pool: &mut Vec<TokenRef>,
+        n: usize,
+        _buyer: &Address,
+    ) -> Vec<TokenRef> {
+        let mut out: Vec<TokenRef> = Vec::new(env);
+
+        // Build entropy seed: ledger sequence (4 bytes) + timestamp (8 bytes).
+        // Using on-chain ledger data as entropy per the issue spec.
+        let seq = env.ledger().sequence();
+        let ts = env.ledger().timestamp();
+        let mut seed_bytes = Bytes::new(env);
+        seed_bytes.extend_from_array(&seq.to_be_bytes());
+        seed_bytes.extend_from_array(&ts.to_be_bytes());
+
+        let hash = env.crypto().sha256(&seed_bytes);
+        let hash_arr = hash.to_array();
+
+        // Use successive 8-byte windows of the hash as random words.
+        // Re-hash when we exhaust the 32 bytes.
+        let mut rand_words: [u64; 4] = [
+            u64::from_be_bytes(hash_arr[0..8].try_into().unwrap()),
+            u64::from_be_bytes(hash_arr[8..16].try_into().unwrap()),
+            u64::from_be_bytes(hash_arr[16..24].try_into().unwrap()),
+            u64::from_be_bytes(hash_arr[24..32].try_into().unwrap()),
+        ];
+        let mut word_idx = 0usize;
+
+        for _ in 0..n {
+            let pool_len = pool.len() as u64;
+            if pool_len == 0 {
+                break;
+            }
+
+            // Refresh entropy when we've used all 4 words.
+            if word_idx >= 4 {
+                let mut rehash_input = Bytes::new(env);
+                for w in rand_words.iter() {
+                    rehash_input.extend_from_array(&w.to_be_bytes());
+                }
+                let new_hash = env.crypto().sha256(&rehash_input);
+                let new_arr = new_hash.to_array();
+                rand_words = [
+                    u64::from_be_bytes(new_arr[0..8].try_into().unwrap()),
+                    u64::from_be_bytes(new_arr[8..16].try_into().unwrap()),
+                    u64::from_be_bytes(new_arr[16..24].try_into().unwrap()),
+                    u64::from_be_bytes(new_arr[24..32].try_into().unwrap()),
+                ];
+                word_idx = 0;
+            }
+
+            let idx = (rand_words[word_idx] % pool_len) as u32;
+            word_idx += 1;
+
+            out.push_back(pool.get(idx).unwrap());
+            pool.remove(idx);
+        }
+
+        out
+    }
+
+    /// Cross-contract NFT transfer helper.
+    fn transfer_nft(
+        env: &Env,
+        nft_contract: &Address,
+        from: &Address,
+        to: &Address,
+        token_id: u32,
+    ) {
+        let args: soroban_sdk::Vec<soroban_sdk::Val> = vec![
+            env,
+            from.clone().into_val(env),
+            to.clone().into_val(env),
+            token_id.into_val(env),
+        ];
+        env.invoke_contract::<()>(nft_contract, &soroban_sdk::Symbol::new(env, "transfer"), args);
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/nft_bundle/src/test.rs
+++ b/contracts/nft_bundle/src/test.rs
@@ -1,0 +1,418 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::Address as _,
+    token, Address, Env,
+};
+
+// ─────────────────────────────────────────────
+// Mock NFT contract
+// ─────────────────────────────────────────────
+
+#[contract]
+pub struct MockNft;
+
+#[contractimpl]
+impl MockNft {
+    pub fn owner_of(env: Env, token_id: u32) -> Address {
+        env.storage()
+            .persistent()
+            .get(&token_id)
+            .unwrap_or_else(|| panic!("token_not_found"))
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, token_id: u32) {
+        from.require_auth();
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&token_id)
+            .unwrap_or_else(|| panic!("token_not_found"));
+        if owner != from {
+            panic!("not_owner");
+        }
+        env.storage().persistent().set(&token_id, &to);
+    }
+
+    pub fn set_owner(env: Env, token_id: u32, owner: Address) {
+        env.storage().persistent().set(&token_id, &owner);
+    }
+}
+
+// ─────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────
+
+fn setup_payment_token<'a>(
+    env: &'a Env,
+    admin: &'a Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let client = token::Client::new(env, &addr);
+    let sac = token::StellarAssetClient::new(env, &addr);
+    (addr, client, sac)
+}
+
+/// Register a MockNft contract and mint `count` tokens to `owner`.
+/// Returns (nft_contract_address, client, Vec<TokenRef>).
+fn setup_nft_pool<'a>(
+    env: &'a Env,
+    owner: &Address,
+    count: u32,
+) -> (Address, MockNftClient<'a>, Vec<TokenRef>) {
+    let nft_addr = env.register_contract(None, MockNft);
+    let nft = MockNftClient::new(env, &nft_addr);
+    let mut pool: Vec<TokenRef> = Vec::new(env);
+    for i in 1..=count {
+        nft.set_owner(&i, owner);
+        pool.push_back(TokenRef {
+            nft_contract: nft_addr.clone(),
+            token_id: i,
+        });
+    }
+    (nft_addr, nft, pool)
+}
+
+fn setup_bundle_contract(env: &Env) -> (Address, NftBundleContractClient) {
+    let addr = env.register_contract(None, NftBundleContract);
+    let client = NftBundleContractClient::new(env, &addr);
+    (addr, client)
+}
+
+// ─────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────
+
+/// Creator can create a fixed bundle; NFTs are locked in the contract.
+#[test]
+fn test_create_fixed_bundle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let (payment_addr, _, _) = setup_payment_token(&env, &admin);
+    let (nft_addr, nft, pool) = setup_nft_pool(&env, &creator, 4);
+    let (bundle_addr, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,       // 2 NFTs per pack → 2 packs
+        &1000i128,
+        &payment_addr,
+    );
+
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.packs_remaining, 2);
+    assert_eq!(b.pack_type, PackType::Fixed);
+    assert_eq!(b.price, 1000);
+    assert_eq!(b.nft_pool.len(), 4);
+    assert_eq!(b.status, BundleStatus::Active);
+
+    // NFTs should now be owned by the bundle contract.
+    assert_eq!(nft.owner_of(&1u32), bundle_addr);
+    assert_eq!(nft.owner_of(&2u32), bundle_addr);
+}
+
+/// Creator can create a blind bundle.
+#[test]
+fn test_create_blind_bundle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let (payment_addr, _, _) = setup_payment_token(&env, &admin);
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 6);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Blind,
+        &pool,
+        &3u32,       // 3 NFTs per pack → 2 packs
+        &500i128,
+        &payment_addr,
+    );
+
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.packs_remaining, 2);
+    assert_eq!(b.pack_type, PackType::Blind);
+}
+
+/// Fixed pack delivers the first N NFTs in pool order.
+#[test]
+fn test_purchase_fixed_pack() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let (payment_addr, _, sac) = setup_payment_token(&env, &admin);
+    sac.mint(&buyer, &5000i128);
+
+    let (nft_addr, nft, pool) = setup_nft_pool(&env, &creator, 4);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,
+        &1000i128,
+        &payment_addr,
+    );
+
+    let received = bundle.purchase_pack(&buyer, &id);
+
+    // Fixed: first 2 tokens (id 1 and 2) delivered.
+    assert_eq!(received.len(), 2);
+    assert_eq!(received.get(0).unwrap().token_id, 1);
+    assert_eq!(received.get(1).unwrap().token_id, 2);
+
+    // Buyer now owns those NFTs.
+    assert_eq!(nft.owner_of(&1u32), buyer);
+    assert_eq!(nft.owner_of(&2u32), buyer);
+
+    // packs_remaining decremented.
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.packs_remaining, 1);
+    assert_eq!(b.nft_pool.len(), 2);
+}
+
+/// Blind pack draws without repeats; pool shrinks correctly.
+#[test]
+fn test_purchase_blind_pack_no_repeats() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let (payment_addr, _, sac) = setup_payment_token(&env, &admin);
+    sac.mint(&buyer, &5000i128);
+
+    let (_, nft, pool) = setup_nft_pool(&env, &creator, 6);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Blind,
+        &pool,
+        &3u32,
+        &500i128,
+        &payment_addr,
+    );
+
+    let received = bundle.purchase_pack(&buyer, &id);
+    assert_eq!(received.len(), 3);
+
+    // All token ids must be distinct.
+    let t0 = received.get(0).unwrap().token_id;
+    let t1 = received.get(1).unwrap().token_id;
+    let t2 = received.get(2).unwrap().token_id;
+    assert_ne!(t0, t1);
+    assert_ne!(t1, t2);
+    assert_ne!(t0, t2);
+
+    // Pool shrinks by 3.
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.nft_pool.len(), 3);
+    assert_eq!(b.packs_remaining, 1);
+}
+
+/// Bundle auto-closes when the last pack is purchased.
+#[test]
+fn test_bundle_closes_when_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let (payment_addr, _, sac) = setup_payment_token(&env, &admin);
+    sac.mint(&buyer, &5000i128);
+
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 2);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,   // 1 pack total
+        &1000i128,
+        &payment_addr,
+    );
+
+    bundle.purchase_pack(&buyer, &id);
+
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.packs_remaining, 0);
+    assert_eq!(b.status, BundleStatus::Closed);
+}
+
+/// Purchasing from an empty / closed bundle panics.
+#[test]
+#[should_panic(expected = "bundle_not_active")]
+fn test_purchase_from_closed_bundle_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let (payment_addr, _, sac) = setup_payment_token(&env, &admin);
+    sac.mint(&buyer, &5000i128);
+
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 2);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,
+        &1000i128,
+        &payment_addr,
+    );
+
+    // Buy the only pack → bundle closes.
+    bundle.purchase_pack(&buyer, &id);
+    // Second attempt must panic.
+    bundle.purchase_pack(&buyer, &id);
+}
+
+/// Creator can cancel an active bundle and withdraw unsold NFTs.
+#[test]
+fn test_creator_cancel_and_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let (payment_addr, _, _) = setup_payment_token(&env, &admin);
+    let (_, nft, pool) = setup_nft_pool(&env, &creator, 4);
+    let (bundle_addr, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,
+        &1000i128,
+        &payment_addr,
+    );
+
+    // NFTs are in the contract.
+    assert_eq!(nft.owner_of(&1u32), bundle_addr);
+
+    bundle.cancel_bundle(&creator, &id);
+
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.status, BundleStatus::Cancelled);
+
+    bundle.withdraw_unsold(&creator, &id);
+
+    // All NFTs returned to creator.
+    assert_eq!(nft.owner_of(&1u32), creator);
+    assert_eq!(nft.owner_of(&2u32), creator);
+    assert_eq!(nft.owner_of(&3u32), creator);
+    assert_eq!(nft.owner_of(&4u32), creator);
+
+    // Pool is empty after withdrawal.
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.nft_pool.len(), 0);
+}
+
+/// Creator can withdraw proceeds after packs are sold.
+#[test]
+fn test_creator_withdraw_proceeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let (payment_addr, payment, sac) = setup_payment_token(&env, &admin);
+    sac.mint(&buyer, &5000i128);
+
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 2);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,
+        &1000i128,
+        &payment_addr,
+    );
+
+    bundle.purchase_pack(&buyer, &id);
+
+    let creator_balance_before = payment.balance(&creator);
+    bundle.withdraw_proceeds(&creator, &id);
+    let creator_balance_after = payment.balance(&creator);
+
+    assert_eq!(creator_balance_after - creator_balance_before, 1000);
+}
+
+/// Non-creator cannot cancel a bundle.
+#[test]
+#[should_panic(expected = "not_creator")]
+fn test_non_creator_cannot_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let (payment_addr, _, _) = setup_payment_token(&env, &admin);
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 2);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Fixed,
+        &pool,
+        &2u32,
+        &1000i128,
+        &payment_addr,
+    );
+
+    bundle.cancel_bundle(&attacker, &id);
+}
+
+/// get_bundle returns correct metadata.
+#[test]
+fn test_get_bundle_metadata() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let (payment_addr, _, _) = setup_payment_token(&env, &admin);
+    let (_, _, pool) = setup_nft_pool(&env, &creator, 6);
+    let (_, bundle) = setup_bundle_contract(&env);
+
+    let id = bundle.create_bundle(
+        &creator,
+        &PackType::Blind,
+        &pool,
+        &3u32,
+        &750i128,
+        &payment_addr,
+    );
+
+    let b = bundle.get_bundle(&id).unwrap();
+    assert_eq!(b.pack_type, PackType::Blind);
+    assert_eq!(b.price, 750);
+    assert_eq!(b.packs_remaining, 2);
+    assert_eq!(b.nft_pool.len(), 6);
+}


### PR DESCRIPTION
---

**feat: NFT Bundle and Pack Contract (#147)**

Closes #147

Implements the full NFT bundle/pack system at `contracts/nft_bundle`.

**What's in this PR**

- `NftBundle` struct — tracks id, creator, pack type (Fixed/Blind), NFT pool, nfts per pack, price, payment token, packs remaining, and status
- `create_bundle` — creator locks NFTs into the contract; validates pool is divisible by pack size, derives total packs automatically
- `purchase_pack` — buyer pays price; Fixed packs deliver the first N NFTs in pool order; Blind packs use SHA-256(ledger sequence + timestamp) as entropy for a no-repeat draw; packs_remaining decrements and bundle auto-closes at zero
- `cancel_bundle` — creator can cancel an active bundle early
- `withdraw_unsold` — creator reclaims remaining NFTs after close or cancel
- `withdraw_proceeds` — creator collects accumulated payment token balance
- `get_bundle` — returns pack type, price, packs remaining, pool size
- Events: `BndlCrtd`, `PckPrchsd`, `BndlClsd`

**Tests**
- Create fixed bundle, create blind bundle
- Purchase fixed pack (deterministic order)
- Purchase blind pack (no-repeat draw, pool shrinks)
- Auto-close when last pack sold
- Rejection on purchase from closed bundle
- Creator cancel + withdraw unsold NFTs
- Creator withdraw proceeds
- Non-creator cancel guard
- `get_bundle` metadata check

**Notes**
- Blind draw uses a Fisher-Yates-style removal from pool so the same NFT can never appear twice in one pack
- `nfts_per_pack` is flexible — not hardcoded to 1 — so creators can define multi-NFT packs