### PR TITLE
power delegate contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
   "contracts/nft_upgrade",
   "contracts/nft_bundle",
   "contracts/puzzle_voting",
+  "contracts/delegation",
 ]
 
 [workspace.dependencies]

--- a/contracts/delegation/Cargo.toml
+++ b/contracts/delegation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "delegation"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/delegation/src/lib.rs
+++ b/contracts/delegation/src/lib.rs
@@ -1,0 +1,131 @@
+#![no_std]
+
+mod storage;
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec, symbol_short};
+use soroban_sdk::token::Client as TokenClient;
+use crate::storage::*;
+
+#[contract]
+pub struct DelegationContract;
+
+#[contractimpl]
+impl DelegationContract {
+    pub fn initialize(env: Env, token_address: Address) {
+        if env.storage().instance().has(&DataKey::TokenAddress) {
+            panic!("Already initialized");
+        }
+        set_token_address(&env, &token_address);
+    }
+
+    pub fn delegate(env: Env, delegator: Address, delegatee: Address) {
+        delegator.require_auth();
+
+        if delegator == delegatee {
+            panic!("Cannot delegate to self");
+        }
+
+        // Circular delegation check
+        let mut curr = delegatee.clone();
+        for _ in 0..10 {
+            if curr == delegator {
+                panic!("Circular delegation detected");
+            }
+            if let Some(d) = get_delegation(&env, &curr) {
+                if d.active {
+                    curr = d.delegatee;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        // Remove from old delegatee if exists
+        if let Some(mut old_d) = get_delegation(&env, &delegator) {
+            if old_d.active {
+                remove_delegator(&env, &old_d.delegatee, &delegator);
+            }
+        }
+
+        // Add to new delegatee
+        add_delegator(&env, &delegatee, &delegator);
+
+        let new_delegation = Delegation {
+            delegator: delegator.clone(),
+            delegatee: delegatee.clone(),
+            delegated_at: env.ledger().timestamp(),
+            active: true,
+        };
+
+        set_delegation(&env, &delegator, &new_delegation);
+
+        env.events().publish((symbol_short!("Delegate"), symbol_short!("Set")), (delegator, delegatee));
+    }
+
+    pub fn revoke_delegation(env: Env, delegator: Address) {
+        delegator.require_auth();
+
+        if let Some(mut d) = get_delegation(&env, &delegator) {
+            if d.active {
+                d.active = false;
+                remove_delegator(&env, &d.delegatee, &delegator);
+                set_delegation(&env, &delegator, &d);
+                env.events().publish((symbol_short!("Delegate"), symbol_short!("Revoked")), delegator);
+            }
+        }
+    }
+
+    pub fn get_delegator_chain(env: Env, start: Address) -> Vec<Address> {
+         let mut chain = Vec::new(&env);
+         let mut current = start.clone();
+         chain.push_back(current.clone());
+         
+         for _ in 0..10 {
+             if let Some(d) = get_delegation(&env, &current) {
+                 if d.active {
+                     current = d.delegatee;
+                     chain.push_back(current.clone());
+                     continue;
+                 }
+             }
+             break;
+         }
+         chain
+    }
+
+    pub fn get_voting_power(env: Env, address: Address) -> i128 {
+        let token = get_token_address(&env);
+        let client = TokenClient::new(&env, &token);
+        
+        if let Some(d) = get_delegation(&env, &address) {
+            if d.active {
+                return 0; // Balance forwarded to delegatee
+            }
+        }
+        
+        let own_balance = client.balance(&address);
+        own_balance + Self::compute_delegated_power(&env, &address, &client, 1, 3)
+    }
+
+    fn compute_delegated_power(env: &Env, delegatee: &Address, client: &TokenClient, depth: u32, max_depth: u32) -> i128 {
+        if depth > max_depth {
+            return 0;
+        }
+        
+        let mut total = 0;
+        let delegators = get_delegators(env, delegatee);
+        
+        for delegator in delegators.iter() {
+            if let Some(d) = get_delegation(env, &delegator) {
+                if d.active && d.delegatee == *delegatee {
+                    let bal = client.balance(&delegator);
+                    total += bal;
+                    total += Self::compute_delegated_power(env, &delegator, client, depth + 1, max_depth);
+                }
+            }
+        }
+        total
+    }
+}

--- a/contracts/delegation/src/storage.rs
+++ b/contracts/delegation/src/storage.rs
@@ -1,0 +1,53 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Delegation {
+    pub delegator: Address,
+    pub delegatee: Address,
+    pub delegated_at: u64,
+    pub active: bool,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Delegation(Address),
+    Delegators(Address),
+    TokenAddress,
+}
+
+pub fn set_token_address(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKey::TokenAddress, token);
+}
+
+pub fn get_token_address(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::TokenAddress).expect("Token not initialized")
+}
+
+pub fn set_delegation(env: &Env, delegator: &Address, delegation: &Delegation) {
+    env.storage().persistent().set(&DataKey::Delegation(delegator.clone()), delegation);
+}
+
+pub fn get_delegation(env: &Env, delegator: &Address) -> Option<Delegation> {
+    env.storage().persistent().get(&DataKey::Delegation(delegator.clone()))
+}
+
+pub fn add_delegator(env: &Env, delegatee: &Address, delegator: &Address) {
+    let mut delegators = get_delegators(env, delegatee);
+    if !delegators.contains(delegator) {
+        delegators.push_back(delegator.clone());
+        env.storage().persistent().set(&DataKey::Delegators(delegatee.clone()), &delegators);
+    }
+}
+
+pub fn remove_delegator(env: &Env, delegatee: &Address, delegator: &Address) {
+    let mut delegators = get_delegators(env, delegatee);
+    if let Some(idx) = delegators.first_index_of(delegator) {
+        delegators.remove(idx);
+        env.storage().persistent().set(&DataKey::Delegators(delegatee.clone()), &delegators);
+    }
+}
+
+pub fn get_delegators(env: &Env, delegatee: &Address) -> Vec<Address> {
+    env.storage().persistent().get(&DataKey::Delegators(delegatee.clone())).unwrap_or_else(|| Vec::new(env))
+}

--- a/contracts/delegation/src/test.rs
+++ b/contracts/delegation/src/test.rs
@@ -1,0 +1,112 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (TokenClient<'a>, StellarAssetClient<'a>) {
+    let contract_id = env.register_stellar_asset_contract(admin.clone());
+    (TokenClient::new(env, &contract_id), StellarAssetClient::new(env, &contract_id))
+}
+
+#[test]
+fn test_delegation_flow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+    let user4 = Address::generate(&env);
+    
+    let (token, token_admin) = create_token(&env, &admin);
+    
+    token_admin.mint(&user1, &1000);
+    token_admin.mint(&user2, &2000);
+    token_admin.mint(&user3, &3000);
+    token_admin.mint(&user4, &4000);
+    
+    let contract_id = env.register_contract(None, DelegationContract);
+    let client = DelegationContractClient::new(&env, &contract_id);
+    
+    client.initialize(&token.address);
+    
+    assert_eq!(client.get_voting_power(&user1), 1000);
+    
+    // User1 delegates to User2
+    client.delegate(&user1, &user2);
+    
+    assert_eq!(client.get_voting_power(&user1), 0);
+    assert_eq!(client.get_voting_power(&user2), 3000); // 2000 + 1000
+    
+    let chain1 = client.get_delegator_chain(&user1);
+    assert_eq!(chain1.len(), 2);
+    assert_eq!(chain1.get(0).unwrap(), user1);
+    assert_eq!(chain1.get(1).unwrap(), user2);
+    
+    // User2 delegates to User3
+    client.delegate(&user2, &user3);
+    
+    assert_eq!(client.get_voting_power(&user2), 0);
+    assert_eq!(client.get_voting_power(&user3), 6000); // 3000 + 2000 + 1000(from user1)
+
+    // User3 delegates to User4
+    client.delegate(&user3, &user4);
+
+    assert_eq!(client.get_voting_power(&user3), 0);
+    assert_eq!(client.get_voting_power(&user4), 10000); // 4000+3000+2000+1000 (3 hops: u4 <- u3 <- u2 <- u1)
+
+    let chain4 = client.get_delegator_chain(&user1);
+    assert_eq!(chain4.len(), 4);
+}
+
+#[test]
+#[should_panic(expected = "Circular delegation detected")]
+fn test_circular_delegation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+    
+    let (token, _) = create_token(&env, &admin);
+    
+    let contract_id = env.register_contract(None, DelegationContract);
+    let client = DelegationContractClient::new(&env, &contract_id);
+    client.initialize(&token.address);
+    
+    client.delegate(&user1, &user2);
+    client.delegate(&user2, &user3);
+    
+    // Should panic
+    client.delegate(&user3, &user1);
+}
+
+#[test]
+fn test_revoke_delegation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    
+    let (token, token_admin) = create_token(&env, &admin);
+    token_admin.mint(&user1, &1000);
+    token_admin.mint(&user2, &2000);
+    
+    let contract_id = env.register_contract(None, DelegationContract);
+    let client = DelegationContractClient::new(&env, &contract_id);
+    client.initialize(&token.address);
+    
+    client.delegate(&user1, &user2);
+    assert_eq!(client.get_voting_power(&user1), 0);
+    assert_eq!(client.get_voting_power(&user2), 3000);
+    
+    client.revoke_delegation(&user1);
+    assert_eq!(client.get_voting_power(&user1), 1000);
+    assert_eq!(client.get_voting_power(&user2), 2000);
+}

--- a/deploy_delegation.sh
+++ b/deploy_delegation.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+echo "Building delegation contract..."
+cargo build --manifest-path contracts/delegation/Cargo.toml --target wasm32-unknown-unknown --release
+
+echo ""
+echo "==== Deployment Instructions ===="
+echo "Since automatic signing wasn't configured with existing keys in the workspace, you can deploy by running:"
+echo "stellar contract deploy \\"
+echo "  --wasm target/wasm32-unknown-unknown/release/delegation.wasm \\"
+echo "  --source puzzle_deployer \\"
+echo "  --network testnet"
+echo ""
+echo "If CLI deployment fails, you can use the manual_deploy.sh approach with stellar laboratory."


### PR DESCRIPTION
Allow token holders to delegate their governance voting power to another address without transferring tokens. Delegatees vote on behalf of their delegators in governance proposals. Delegation is revocable at any time and supports chained delegation (A delegates to B who delegates to C, resolved at vote time).

Closes #167