### PR TITLE
 Flash Challenge and Rapid Fire Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ members = [
   "contracts/loyalty_points",
   "contracts/nft_upgrade",
   "contracts/nft_bundle",
-  "contracts/puzzle_voting",
+  "contracts/puzzle_voting", "contracts/flash_challenge",
 ]
 
 [workspace.dependencies]

--- a/contracts/flash_challenge/Cargo.toml
+++ b/contracts/flash_challenge/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "flash-challenge"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/flash_challenge/src/lib.rs
+++ b/contracts/flash_challenge/src/lib.rs
@@ -1,0 +1,181 @@
+#![no_std]
+
+mod storage;
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec, symbol_short, BytesN, Symbol};
+use soroban_sdk::token::Client as TokenClient;
+use crate::storage::*;
+
+#[contract]
+pub struct FlashChallengeContract;
+
+#[contractimpl]
+impl FlashChallengeContract {
+    pub fn initialize(env: Env, admin: Address, token: Address, oracle: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+        set_token_address(&env, &token);
+        set_oracle_address(&env, &oracle);
+    }
+
+    pub fn schedule(
+        env: Env,
+        puzzle_id: u32,
+        reward_pool: i128,
+        start_at: u64,
+        duration_minutes: u64,
+        max_winners: u32,
+    ) -> u32 {
+        let admin = get_admin(&env);
+        admin.require_auth();
+
+        if reward_pool <= 0 || max_winners == 0 || duration_minutes == 0 {
+            panic!("Invalid parameters");
+        }
+
+        let token = get_token_address(&env);
+        let client = TokenClient::new(&env, &token);
+        
+        // Transfer reward pool from admin to contract
+        client.transfer(&admin, &env.current_contract_address(), &reward_pool);
+
+        let id = increment_challenge_count(&env);
+        let end_at = start_at + (duration_minutes * 60);
+
+        let challenge = FlashChallenge {
+            id,
+            puzzle_id,
+            reward_pool,
+            max_winners,
+            start_at,
+            end_at,
+            winners: Vec::new(&env),
+            status: ChallengeStatus::Scheduled,
+        };
+
+        set_challenge(&env, id, &challenge);
+        
+        env.events().publish((symbol_short!("Flash"), symbol_short!("Scheduled")), id);
+
+        id
+    }
+
+    pub fn submit_solution(env: Env, challenge_id: u32, player: Address, solution_hash: BytesN<32>) {
+        player.require_auth();
+
+        let mut challenge = get_challenge(&env, challenge_id).expect("Challenge not found");
+        
+        if challenge.status == ChallengeStatus::Completed || challenge.status == ChallengeStatus::Expired {
+            panic!("Challenge not active");
+        }
+
+        let now = env.ledger().timestamp();
+        if now < challenge.start_at {
+            panic!("Challenge hasn't started");
+        }
+        
+        if now > challenge.end_at {
+            panic!("Challenge expired");
+        }
+        
+        if challenge.status == ChallengeStatus::Scheduled {
+            challenge.status = ChallengeStatus::Active;
+        }
+
+        if challenge.winners.contains(&player) {
+            panic!("Already a winner");
+        }
+
+        // Oracle verifies
+        let oracle = get_oracle_address(&env);
+        let is_correct: bool = env.invoke_contract(
+            &oracle,
+            &Symbol::new(&env, "verify"),
+            (challenge.puzzle_id, solution_hash.clone()).into_val(&env)
+        );
+
+        if !is_correct {
+            panic!("Incorrect solution");
+        }
+
+        challenge.winners.push_back(player.clone());
+        let position = challenge.winners.len();
+        
+        env.events().publish((symbol_short!("Flash"), symbol_short!("Accepted")), (player, position));
+
+        if challenge.winners.len() == challenge.max_winners {
+            challenge.status = ChallengeStatus::Completed;
+            
+            // Payout immediately since max winners reached!
+            let amount_each = challenge.reward_pool / (challenge.max_winners as i128);
+            let token = get_token_address(&env);
+            let client = TokenClient::new(&env, &token);
+            let contract_addr = env.current_contract_address();
+            
+            for winner in challenge.winners.iter() {
+                client.transfer(&contract_addr, &winner, &amount_each);
+            }
+            
+            env.events().publish((symbol_short!("Flash"), symbol_short!("Completed")), (challenge.winners.clone(), amount_each));
+        }
+
+        set_challenge(&env, challenge_id, &challenge);
+    }
+    
+    pub fn expire_challenge(env: Env, challenge_id: u32) {
+        let mut challenge = get_challenge(&env, challenge_id).expect("Challenge not found");
+        let now = env.ledger().timestamp();
+        
+        if now <= challenge.end_at {
+            panic!("Challenge has not ended yet");
+        }
+        
+        if challenge.status == ChallengeStatus::Completed || challenge.status == ChallengeStatus::Expired {
+            panic!("Already finalized");
+        }
+        
+        challenge.status = ChallengeStatus::Expired;
+        
+        let mut unallocated = challenge.reward_pool;
+        let token_addr = get_token_address(&env);
+        let token = TokenClient::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+        
+        let num_winners = challenge.winners.len();
+        if num_winners > 0 {
+            let amount_each = challenge.reward_pool / (challenge.max_winners as i128); 
+            for winner in challenge.winners.iter() {
+                token.transfer(&contract_addr, &winner, &amount_each);
+                unallocated -= amount_each;
+            }
+        }
+        
+        if unallocated > 0 {
+            let admin = get_admin(&env);
+            token.transfer(&contract_addr, &admin, &unallocated);
+        }
+        
+        set_challenge(&env, challenge_id, &challenge);
+        env.events().publish((symbol_short!("Flash"), symbol_short!("Expired")), challenge_id);
+    }
+
+    pub fn get_challenge(env: Env, id: u32) -> (ChallengeStatus, Vec<Address>, u64) {
+        let challenge = get_challenge(&env, id).expect("Not found");
+        let now = env.ledger().timestamp();
+        let mut time_remaining = 0;
+        
+        if now < challenge.end_at && challenge.status != ChallengeStatus::Completed && challenge.status != ChallengeStatus::Expired {
+            if now >= challenge.start_at {
+                time_remaining = challenge.end_at - now;
+            } else {
+                time_remaining = challenge.end_at - challenge.start_at; 
+            }
+        }
+        
+        (challenge.status, challenge.winners, time_remaining)
+    }
+}

--- a/contracts/flash_challenge/src/lib.rs
+++ b/contracts/flash_challenge/src/lib.rs
@@ -4,7 +4,7 @@ mod storage;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec, symbol_short, BytesN, Symbol};
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec, symbol_short, BytesN, Symbol, IntoVal};
 use soroban_sdk::token::Client as TokenClient;
 use crate::storage::*;
 

--- a/contracts/flash_challenge/src/storage.rs
+++ b/contracts/flash_challenge/src/storage.rs
@@ -1,0 +1,71 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChallengeStatus {
+    Scheduled,
+    Active,
+    Completed,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FlashChallenge {
+    pub id: u32,
+    pub puzzle_id: u32,
+    pub reward_pool: i128,
+    pub max_winners: u32,
+    pub start_at: u64,
+    pub end_at: u64,
+    pub winners: Vec<Address>,
+    pub status: ChallengeStatus,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    TokenAddress,
+    OracleAddress,
+    Challenge(u32),
+    ChallengeCount,
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).expect("Admin not initialized")
+}
+
+pub fn set_token_address(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKey::TokenAddress, token);
+}
+
+pub fn get_token_address(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::TokenAddress).expect("Token not initialized")
+}
+
+pub fn set_oracle_address(env: &Env, oracle: &Address) {
+    env.storage().instance().set(&DataKey::OracleAddress, oracle);
+}
+
+pub fn get_oracle_address(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::OracleAddress).expect("Oracle not initialized")
+}
+
+pub fn set_challenge(env: &Env, id: u32, challenge: &FlashChallenge) {
+    env.storage().persistent().set(&DataKey::Challenge(id), challenge);
+}
+
+pub fn get_challenge(env: &Env, id: u32) -> Option<FlashChallenge> {
+    env.storage().persistent().get(&DataKey::Challenge(id))
+}
+
+pub fn increment_challenge_count(env: &Env) -> u32 {
+    let mut count = env.storage().instance().get(&DataKey::ChallengeCount).unwrap_or(0);
+    count += 1;
+    env.storage().instance().set(&DataKey::ChallengeCount, &count);
+    count
+}

--- a/contracts/flash_challenge/src/test.rs
+++ b/contracts/flash_challenge/src/test.rs
@@ -1,0 +1,106 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, BytesN, Env, contract, contractimpl};
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (TokenClient<'a>, StellarAssetClient<'a>) {
+    let contract_id = env.register_stellar_asset_contract(admin.clone());
+    (TokenClient::new(env, &contract_id), StellarAssetClient::new(env, &contract_id))
+}
+
+#[contract]
+pub struct MockOracle;
+
+#[contractimpl]
+impl MockOracle {
+    pub fn verify(_env: Env, _puzzle_id: u32, hash: BytesN<32>) -> bool {
+        let first_byte = hash.to_array()[0];
+        first_byte == 1
+    }
+}
+
+#[test]
+fn test_flash_challenge_flow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let (token, token_admin) = create_token(&env, &admin);
+    let oracle_id = env.register_contract(None, MockOracle);
+    
+    let contract_id = env.register_contract(None, FlashChallengeContract);
+    let client = FlashChallengeContractClient::new(&env, &contract_id);
+    
+    client.initialize(&admin, &token.address, &oracle_id);
+    
+    token_admin.mint(&admin, &10000);
+    
+    env.ledger().set_timestamp(1_000);
+    
+    let c_id = client.schedule(&1, &1000, &1_000, &15, &2);
+    
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let player3 = Address::generate(&env);
+    
+    let bad_hash = BytesN::from_array(&env, &[0; 32]);
+    let good_hash = BytesN::from_array(&env, &[1; 32]); 
+    
+    let res = client.try_submit_solution(&c_id, &player1, &bad_hash);
+    assert!(res.is_err()); 
+    
+    client.submit_solution(&c_id, &player1, &good_hash);
+    
+    let (status, winners, remaining) = client.get_challenge(&c_id);
+    assert_eq!(status, ChallengeStatus::Active);
+    assert_eq!(winners.len(), 1);
+    assert_eq!(remaining, 15 * 60);
+    
+    // player2 hits max winners
+    client.submit_solution(&c_id, &player2, &good_hash);
+    
+    let (status2, winners2, _) = client.get_challenge(&c_id);
+    assert_eq!(status2, ChallengeStatus::Completed);
+    assert_eq!(winners2.len(), 2);
+    
+    assert_eq!(token.balance(&player1), 500);
+    assert_eq!(token.balance(&player2), 500);
+    
+    let res3 = client.try_submit_solution(&c_id, &player3, &good_hash);
+    assert!(res3.is_err());
+}
+
+#[test]
+fn test_flash_challenge_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let (token, token_admin) = create_token(&env, &admin);
+    let oracle_id = env.register_contract(None, MockOracle);
+    
+    let contract_id = env.register_contract(None, FlashChallengeContract);
+    let client = FlashChallengeContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token.address, &oracle_id);
+    
+    token_admin.mint(&admin, &10000);
+    env.ledger().set_timestamp(1_000);
+    
+    let c_id = client.schedule(&1, &1000, &1_000, &15, &2);
+    
+    let player1 = Address::generate(&env);
+    let good_hash = BytesN::from_array(&env, &[1; 32]);
+    
+    client.submit_solution(&c_id, &player1, &good_hash);
+    
+    env.ledger().set_timestamp(1_000 + 900 + 1);
+    
+    client.expire_challenge(&c_id);
+    
+    let (status, _, _) = client.get_challenge(&c_id);
+    assert_eq!(status, ChallengeStatus::Expired);
+    
+    assert_eq!(token.balance(&player1), 500);
+    assert_eq!(token.balance(&admin), 10000 - 1000 + 500); 
+}


### PR DESCRIPTION
Implement short-burst flash challenges — 15-minute windows where a high-reward puzzle opens to all players simultaneously. The first N players to submit a correct solution share the prize pool equally. Flash challenges are admin-scheduled and auto-expire if not enough solvers participate.

Closes #170