### PR TITLE
NFT Composability and Trait Merging Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ members = [
   "contracts/loyalty_points",
   "contracts/nft_upgrade",
   "contracts/nft_bundle",
-  "contracts/puzzle_voting",
+  "contracts/puzzle_voting", "contracts/nft_composability",
 ]
 
 [workspace.dependencies]

--- a/contracts/nft_composability/Cargo.toml
+++ b/contracts/nft_composability/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nft-composability"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/nft_composability/src/lib.rs
+++ b/contracts/nft_composability/src/lib.rs
@@ -1,0 +1,153 @@
+#![no_std]
+
+mod storage;
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Map, Symbol, Vec, symbol_short};
+use crate::storage::*;
+
+#[contract]
+pub struct NftComposabilityContract;
+
+#[contractimpl]
+impl NftComposabilityContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+    }
+
+    pub fn register_traits(env: Env, traits: Vec<Symbol>) {
+        let admin = get_admin(&env);
+        admin.require_auth();
+        set_required_traits(&env, &traits);
+    }
+
+    /// Mint a Gen 0 NFT (for setting up base parents)
+    pub fn mint_base(env: Env, owner: Address, traits: Map<Symbol, Symbol>) -> u32 {
+        let admin = get_admin(&env);
+        admin.require_auth();
+
+        let req_traits = get_required_traits(&env);
+        for required_key in req_traits.iter() {
+            if !traits.contains_key(required_key) {
+                panic!("Missing required trait");
+            }
+        }
+
+        let id = increment_supply(&env);
+        let nft = CompositeNFT {
+            token_id: id,
+            owner,
+            parent_a: 0,
+            parent_b: 0,
+            inherited_traits: traits,
+            merge_timestamp: env.ledger().timestamp(),
+            is_burned: false,
+        };
+
+        set_token(&env, id, &nft);
+        id
+    }
+
+    pub fn merge(env: Env, owner: Address, token_a: u32, token_b: u32, selections: Vec<TraitSelection>) -> u32 {
+        owner.require_auth();
+
+        if token_a == token_b {
+            panic!("Cannot merge identical tokens");
+        }
+
+        let parent_a = get_token(&env, token_a).expect("Token A not found");
+        let parent_b = get_token(&env, token_b).expect("Token B not found");
+
+        if parent_a.is_burned || parent_b.is_burned {
+            panic!("Cannot merge burned tokens");
+        }
+
+        if parent_a.owner != owner || parent_b.owner != owner {
+            panic!("Not owner of both parents");
+        }
+
+        let req_traits = get_required_traits(&env);
+        let mut new_traits: Map<Symbol, Symbol> = Map::new(&env);
+        
+        // Track which traits have been filled
+        let mut filled_keys: Map<Symbol, bool> = Map::new(&env);
+
+        for selection in selections.iter() {
+            let val = if selection.source == 1 {
+                parent_a.inherited_traits.get(selection.trait_key.clone())
+            } else if selection.source == 2 {
+                parent_b.inherited_traits.get(selection.trait_key.clone())
+            } else {
+                panic!("Invalid source");
+            };
+
+            let trait_val = val.expect("Parent does not have the selected trait");
+            new_traits.set(selection.trait_key.clone(), trait_val);
+            filled_keys.set(selection.trait_key, true);
+        }
+
+        // Validate all required traits are present in the new set
+        for required_key in req_traits.iter() {
+            if !filled_keys.contains_key(required_key) {
+                panic!("Selections missing required trait");
+            }
+        }
+
+        // Burn parents
+        let mut burn_a = parent_a.clone();
+        burn_a.is_burned = true;
+        set_token(&env, token_a, &burn_a);
+
+        let mut burn_b = parent_b.clone();
+        burn_b.is_burned = true;
+        set_token(&env, token_b, &burn_b);
+
+        let new_id = increment_supply(&env);
+        let new_nft = CompositeNFT {
+            token_id: new_id,
+            owner: owner.clone(),
+            parent_a: token_a,
+            parent_b: token_b,
+            inherited_traits: new_traits,
+            merge_timestamp: env.ledger().timestamp(),
+            is_burned: false,
+        };
+
+        set_token(&env, new_id, &new_nft);
+
+        env.events().publish((symbol_short!("Merged"), symbol_short!("NFTs")), (token_a, token_b, new_id, owner));
+
+        new_id
+    }
+
+    pub fn get_nft(env: Env, token_id: u32) -> Option<CompositeNFT> {
+        get_token(&env, token_id)
+    }
+
+    pub fn get_lineage(env: Env, token_id: u32) -> Vec<u32> {
+        let mut lineage = Vec::new(&env);
+        Self::recurse_lineage(&env, token_id, &mut lineage);
+        lineage
+    }
+
+    fn recurse_lineage(env: &Env, token_id: u32, lineage: &mut Vec<u32>) {
+        if token_id == 0 {
+            return;
+        }
+        
+        let token_opt = get_token(env, token_id);
+        if let Some(token) = token_opt {
+            lineage.push_back(token_id);
+            if token.parent_a != 0 {
+                Self::recurse_lineage(env, token.parent_a, lineage);
+            }
+            if token.parent_b != 0 {
+                Self::recurse_lineage(env, token.parent_b, lineage);
+            }
+        }
+    }
+}

--- a/contracts/nft_composability/src/storage.rs
+++ b/contracts/nft_composability/src/storage.rs
@@ -1,0 +1,63 @@
+use soroban_sdk::{contracttype, Address, Env, Map, Symbol, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompositeNFT {
+    pub token_id: u32,
+    pub owner: Address,
+    pub parent_a: u32,
+    pub parent_b: u32,
+    pub inherited_traits: Map<Symbol, Symbol>,
+    pub merge_timestamp: u64,
+    pub is_burned: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraitSelection {
+    pub trait_key: Symbol,
+    pub source: u32, // 1 for parent_a, 2 for parent_b
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    RequiredTraits,
+    Token(u32),
+    TokenSupply,
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).expect("Admin not set")
+}
+
+pub fn set_required_traits(env: &Env, traits: &Vec<Symbol>) {
+    env.storage().instance().set(&DataKey::RequiredTraits, traits);
+}
+
+pub fn get_required_traits(env: &Env) -> Vec<Symbol> {
+    env.storage().instance().get(&DataKey::RequiredTraits).unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn increment_supply(env: &Env) -> u32 {
+    let mut current = env.storage().instance().get(&DataKey::TokenSupply).unwrap_or(0);
+    current += 1;
+    env.storage().instance().set(&DataKey::TokenSupply, &current);
+    current
+}
+
+pub fn set_token(env: &Env, id: u32, token: &CompositeNFT) {
+    env.storage().persistent().set(&DataKey::Token(id), token);
+}
+
+pub fn remove_token(env: &Env, id: u32) {
+    env.storage().persistent().remove(&DataKey::Token(id));
+}
+
+pub fn get_token(env: &Env, id: u32) -> Option<CompositeNFT> {
+    env.storage().persistent().get(&DataKey::Token(id))
+}

--- a/contracts/nft_composability/src/test.rs
+++ b/contracts/nft_composability/src/test.rs
@@ -1,0 +1,119 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Map, Symbol, Vec, contract, contractimpl};
+
+#[test]
+fn test_nft_composability_flow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, NftComposabilityContract);
+    let client = NftComposabilityContractClient::new(&env, &contract_id);
+    
+    client.initialize(&admin);
+    
+    let mut req_traits = Vec::new(&env);
+    req_traits.push_back(Symbol::new(&env, "Color"));
+    req_traits.push_back(Symbol::new(&env, "Weapon"));
+    client.register_traits(&req_traits);
+    
+    let owner = Address::generate(&env);
+    
+    let mut traits1 = Map::new(&env);
+    traits1.set(Symbol::new(&env, "Color"), Symbol::new(&env, "Red"));
+    traits1.set(Symbol::new(&env, "Weapon"), Symbol::new(&env, "Sword"));
+    let token1 = client.mint_base(&owner, &traits1);
+    
+    let mut traits2 = Map::new(&env);
+    traits2.set(Symbol::new(&env, "Color"), Symbol::new(&env, "Blue"));
+    traits2.set(Symbol::new(&env, "Weapon"), Symbol::new(&env, "Bow"));
+    let token2 = client.mint_base(&owner, &traits2);
+    
+    // Merge: Take Color from 1, Weapon from 2
+    let mut selections = Vec::new(&env);
+    selections.push_back(TraitSelection { trait_key: Symbol::new(&env, "Color"), source: 1 });
+    selections.push_back(TraitSelection { trait_key: Symbol::new(&env, "Weapon"), source: 2 });
+    
+    let merged_id = client.merge(&owner, &token1, &token2, &selections);
+    
+    let nft1 = client.get_nft(&token1).unwrap();
+    assert!(nft1.is_burned);
+    
+    let merged_nft = client.get_nft(&merged_id).unwrap();
+    assert!(!merged_nft.is_burned);
+    assert_eq!(merged_nft.parent_a, token1);
+    assert_eq!(merged_nft.parent_b, token2);
+    assert_eq!(merged_nft.inherited_traits.get(Symbol::new(&env, "Color")).unwrap(), Symbol::new(&env, "Red"));
+    assert_eq!(merged_nft.inherited_traits.get(Symbol::new(&env, "Weapon")).unwrap(), Symbol::new(&env, "Bow"));
+    
+    // Check lineage
+    let lineage = client.get_lineage(&merged_id);
+    // Should contain merged_id, token1, token2 (order may vary based on recursion preorder)
+    assert!(lineage.contains(&merged_id));
+    assert!(lineage.contains(&token1));
+    assert!(lineage.contains(&token2));
+}
+
+#[test]
+#[should_panic(expected = "Selections missing required trait")]
+fn test_missing_trait_selection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, NftComposabilityContract);
+    let client = NftComposabilityContractClient::new(&env, &contract_id);
+    
+    client.initialize(&admin);
+    let mut req_traits = Vec::new(&env);
+    req_traits.push_back(Symbol::new(&env, "Color"));
+    req_traits.push_back(Symbol::new(&env, "Weapon"));
+    client.register_traits(&req_traits);
+    
+    let owner = Address::generate(&env);
+    let mut traits = Map::new(&env);
+    traits.set(Symbol::new(&env, "Color"), Symbol::new(&env, "Red"));
+    traits.set(Symbol::new(&env, "Weapon"), Symbol::new(&env, "Sword"));
+    
+    let t1 = client.mint_base(&owner, &traits);
+    let t2 = client.mint_base(&owner, &traits);
+    
+    // Only select one trait
+    let mut selections = Vec::new(&env);
+    selections.push_back(TraitSelection { trait_key: Symbol::new(&env, "Color"), source: 1 });
+    
+    client.merge(&owner, &t1, &t2, &selections);
+}
+
+#[test]
+#[should_panic(expected = "Cannot merge burned tokens")]
+fn test_double_merge_burned() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, NftComposabilityContract);
+    let client = NftComposabilityContractClient::new(&env, &contract_id);
+    
+    client.initialize(&admin);
+    let mut req_traits = Vec::new(&env);
+    req_traits.push_back(Symbol::new(&env, "Color"));
+    client.register_traits(&req_traits);
+    
+    let owner = Address::generate(&env);
+    let mut traits = Map::new(&env);
+    traits.set(Symbol::new(&env, "Color"), Symbol::new(&env, "Red"));
+    
+    let t1 = client.mint_base(&owner, &traits);
+    let t2 = client.mint_base(&owner, &traits);
+    let t3 = client.mint_base(&owner, &traits);
+    
+    let mut sel = Vec::new(&env);
+    sel.push_back(TraitSelection { trait_key: Symbol::new(&env, "Color"), source: 1 });
+    
+    client.merge(&owner, &t1, &t2, &sel);
+    // t1 is now burned, try to merge it again
+    client.merge(&owner, &t1, &t3, &sel);
+}


### PR DESCRIPTION

Allow players to merge two NFTs to create a new composite NFT that inherits selected traits from both parents. The parent NFTs are burned in the process. Merged NFTs carry a provenance chain linking back to the original parents, enabling verifiable lineage on-chain.

Closes #169