### PR TITLE
feat: add tiered puzzle access subscription contract (#168)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
   "contracts/delegation",
   "contracts/identity",
   "contracts/token_swap",
+  "contracts/puzzle_subscription_tier",
 ]
 
 [workspace.dependencies]

--- a/contracts/puzzle_subscription_tier/Cargo.toml
+++ b/contracts/puzzle_subscription_tier/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "puzzle_subscription_tier"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.7.7"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.7.7", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/puzzle_subscription_tier/src/lib.rs
+++ b/contracts/puzzle_subscription_tier/src/lib.rs
@@ -1,0 +1,443 @@
+#![no_std]
+
+mod tests;
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, token, Address, Env, Symbol, Vec, String,
+};
+
+// ─────────────────────────────────────────────────────────
+// TIME CONSTANTS
+// ─────────────────────────────────────────────────────────
+
+#[cfg(not(test))]
+const SECONDS_PER_DAY: u64 = 86_400;
+#[cfg(test)]
+const SECONDS_PER_DAY: u64 = 1;
+
+// ─────────────────────────────────────────────────────────
+// TIERS
+// ─────────────────────────────────────────────────────────
+
+/// Subscription tier levels. Higher numeric value means higher access.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Tier {
+    Free = 0,
+    Pro = 1,
+    Elite = 2,
+}
+
+// ─────────────────────────────────────────────────────────
+// DATA KEYS
+// ─────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Contract-wide admin config
+    Admin,
+    /// Payment token address
+    PaymentToken,
+    /// TierConfig keyed by Tier enum value
+    TierConfig(Tier),
+    /// Subscription record keyed by subscription id
+    Subscription(u64),
+    /// Maps player Address → their current subscription id
+    PlayerSub(Address),
+    /// Monotonic counter for subscription ids
+    NextId,
+}
+
+// ─────────────────────────────────────────────────────────
+// STRUCTS
+// ─────────────────────────────────────────────────────────
+
+/// Per-subscription state stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Subscription {
+    /// The subscriber's address.
+    pub holder: Address,
+    /// Active tier level.
+    pub tier: Tier,
+    /// Ledger timestamp when the subscription was originally created.
+    pub started_at: u64,
+    /// Ledger timestamp at which this subscription expires.
+    pub expires_at: u64,
+    /// When true, anyone may call `renew` to extend the subscription.
+    pub auto_renew: bool,
+}
+
+/// Configuration for a single tier, set by the admin.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TierConfig {
+    /// The tier this config applies to.
+    pub tier: Tier,
+    /// Token amount required to subscribe (or pay difference on upgrade).
+    pub price: i128,
+    /// How many days each subscription period lasts.
+    pub duration_days: u64,
+    /// Numeric access level exposed to other contracts.
+    pub puzzle_access_level: u32,
+    /// Arbitrary feature flag strings (e.g. "hints", "leaderboard").
+    pub feature_flags: Vec<String>,
+}
+
+// ─────────────────────────────────────────────────────────
+// EVENTS  (topic symbols)
+// ─────────────────────────────────────────────────────────
+
+const EVT_SUBSCRIBED: &str = "subscribed";
+const EVT_RENEWED: &str = "renewed";
+const EVT_UPGRADED: &str = "upgraded";
+const EVT_CANCELLED: &str = "cancelled";
+
+// ─────────────────────────────────────────────────────────
+// CONTRACT
+// ─────────────────────────────────────────────────────────
+
+#[contract]
+pub struct PuzzleSubscriptionTierContract;
+
+#[contractimpl]
+impl PuzzleSubscriptionTierContract {
+    // ──────────────── INITIALIZATION ────────────────
+
+    /// Initialize the contract.  Must be called once before any other function.
+    pub fn initialize(env: Env, admin: Address, payment_token: Address) {
+        admin.require_auth();
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::PaymentToken, &payment_token);
+        env.storage().persistent().set(&DataKey::NextId, &1u64);
+    }
+
+    // ──────────────── ADMIN ────────────────
+
+    /// Set (or update) the configuration for a tier.  Admin only.
+    pub fn set_tier_config(
+        env: Env,
+        admin: Address,
+        tier: Tier,
+        price: i128,
+        duration_days: u64,
+        puzzle_access_level: u32,
+        feature_flags: Vec<String>,
+    ) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if price < 0 {
+            panic!("price must be non-negative");
+        }
+        if duration_days == 0 {
+            panic!("duration_days must be > 0");
+        }
+
+        let cfg = TierConfig {
+            tier,
+            price,
+            duration_days,
+            puzzle_access_level,
+            feature_flags,
+        };
+        env.storage().persistent().set(&DataKey::TierConfig(tier), &cfg);
+    }
+
+    // ──────────────── SUBSCRIBE ────────────────
+
+    /// Subscribe to a tier (or upgrade inline).  Player pays the tier price.
+    /// If the player has an existing active subscription it must be expired first;
+    /// use `upgrade` for mid-period tier changes.
+    pub fn subscribe(env: Env, player: Address, tier: Tier) -> u64 {
+        player.require_auth();
+
+        let cfg = Self::get_tier_config_or_panic(&env, tier);
+
+        // If a previous subscription exists and is still active, reject.
+        if let Some(sub_id) = Self::player_sub_id(&env, &player) {
+            let sub: Subscription = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Subscription(sub_id))
+                .unwrap();
+            let now = env.ledger().timestamp();
+            if sub.expires_at > now {
+                panic!("existing subscription still active; use upgrade or wait for expiry");
+            }
+        }
+
+        // Charge only if tier has a price (Free tier = 0).
+        if cfg.price > 0 {
+            let payment_token: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PaymentToken)
+                .unwrap();
+            let token_client = token::Client::new(&env, &payment_token);
+            token_client.transfer(&player, &env.current_contract_address(), &cfg.price);
+        }
+
+        let now = env.ledger().timestamp();
+        let sub_id = Self::next_id(&env);
+
+        let sub = Subscription {
+            holder: player.clone(),
+            tier,
+            started_at: now,
+            expires_at: now + cfg.duration_days * SECONDS_PER_DAY,
+            auto_renew: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlayerSub(player.clone()), &sub_id);
+
+        env.events().publish(
+            (Symbol::new(&env, EVT_SUBSCRIBED), player),
+            (sub_id, tier as u32),
+        );
+
+        sub_id
+    }
+
+    // ──────────────── RENEW ────────────────
+
+    /// Extend an existing subscription by one period (duration_days).
+    /// If `auto_renew` is true anyone may call this; otherwise the holder must sign.
+    pub fn renew(env: Env, caller: Address, subscription_id: u64) {
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("subscription not found");
+
+        if sub.auto_renew {
+            // Anyone may trigger auto-renewal; no specific auth required beyond tx signing.
+            caller.require_auth();
+        } else {
+            // Manual renewal requires the holder to authorise.
+            sub.holder.require_auth();
+        }
+
+        let cfg = Self::get_tier_config_or_panic(&env, sub.tier);
+
+        if cfg.price > 0 {
+            let payment_token: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PaymentToken)
+                .unwrap();
+            let token_client = token::Client::new(&env, &payment_token);
+            token_client.transfer(&sub.holder, &env.current_contract_address(), &cfg.price);
+        }
+
+        let now = env.ledger().timestamp();
+        // Always extend from max(now, current expires_at) so renewals stack properly.
+        let base = if sub.expires_at > now {
+            sub.expires_at
+        } else {
+            now
+        };
+        sub.expires_at = base + cfg.duration_days * SECONDS_PER_DAY;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscription_id), &sub);
+
+        env.events().publish(
+            (Symbol::new(&env, EVT_RENEWED), sub.holder),
+            (subscription_id, sub.expires_at),
+        );
+    }
+
+    // ──────────────── UPGRADE ────────────────
+
+    /// Upgrade an active subscription to a higher tier.
+    /// Prorates the remaining time: the unused value from the current tier is
+    /// subtracted from the new tier's price before charging.
+    /// The subscription period is reset to a full period of the new tier.
+    pub fn upgrade(env: Env, subscription_id: u64, new_tier: Tier) {
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("subscription not found");
+
+        sub.holder.require_auth();
+
+        let now = env.ledger().timestamp();
+        if sub.expires_at <= now {
+            panic!("subscription has expired; please subscribe again");
+        }
+
+        if (new_tier as u32) <= (sub.tier as u32) {
+            panic!("can only upgrade to a higher tier");
+        }
+
+        let old_cfg = Self::get_tier_config_or_panic(&env, sub.tier);
+        let new_cfg = Self::get_tier_config_or_panic(&env, new_tier);
+
+        // Proration: remaining fraction of the old period × old price.
+        let old_period = old_cfg.duration_days * SECONDS_PER_DAY;
+        let remaining_secs = sub.expires_at.saturating_sub(now);
+
+        // remaining_value = old_price * remaining_secs / old_period  (integer arithmetic)
+        let remaining_value: i128 = if old_period > 0 && old_cfg.price > 0 {
+            (old_cfg.price * remaining_secs as i128) / old_period as i128
+        } else {
+            0
+        };
+
+        let charge = (new_cfg.price - remaining_value).max(0);
+
+        if charge > 0 {
+            let payment_token: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PaymentToken)
+                .unwrap();
+            let token_client = token::Client::new(&env, &payment_token);
+            token_client.transfer(&sub.holder, &env.current_contract_address(), &charge);
+        }
+
+        let old_tier = sub.tier;
+        sub.tier = new_tier;
+        sub.expires_at = now + new_cfg.duration_days * SECONDS_PER_DAY;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscription_id), &sub);
+
+        env.events().publish(
+            (Symbol::new(&env, EVT_UPGRADED), sub.holder),
+            (subscription_id, old_tier as u32, new_tier as u32, charge),
+        );
+    }
+
+    // ──────────────── CANCEL ────────────────
+
+    /// Cancel a subscription: disables auto-renewal so it runs out at `expires_at`.
+    pub fn cancel(env: Env, subscription_id: u64) {
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("subscription not found");
+
+        sub.holder.require_auth();
+
+        sub.auto_renew = false;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscription_id), &sub);
+
+        env.events().publish(
+            (Symbol::new(&env, EVT_CANCELLED), sub.holder),
+            subscription_id,
+        );
+    }
+
+    // ──────────────── ACCESS GATE ────────────────
+
+    /// Returns true if `player` has an active subscription whose tier is
+    /// greater than or equal to `required_tier`.
+    /// Safe to call from other contracts as a trustless access check.
+    pub fn has_access(env: Env, player: Address, required_tier: Tier) -> bool {
+        let sub_id = match Self::player_sub_id(&env, &player) {
+            Some(id) => id,
+            None => return required_tier == Tier::Free,
+        };
+
+        let sub: Subscription = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(sub_id))
+        {
+            Some(s) => s,
+            None => return required_tier == Tier::Free,
+        };
+
+        let now = env.ledger().timestamp();
+        if sub.expires_at <= now {
+            // Expired subscription — only Free tier passes.
+            return required_tier == Tier::Free;
+        }
+
+        (sub.tier as u32) >= (required_tier as u32)
+    }
+
+    // ──────────────── QUERIES ────────────────
+
+    /// Return the subscription record for the given id.
+    pub fn get_subscription(env: Env, subscription_id: u64) -> Subscription {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("subscription not found")
+    }
+
+    /// Return the subscription id for a player, if any.
+    pub fn get_player_subscription_id(env: Env, player: Address) -> Option<u64> {
+        Self::player_sub_id(&env, &player)
+    }
+
+    /// Return the TierConfig for a tier.
+    pub fn get_tier_config(env: Env, tier: Tier) -> TierConfig {
+        Self::get_tier_config_or_panic(&env, tier)
+    }
+
+    /// Enable or disable auto-renew for a subscription.
+    pub fn set_auto_renew(env: Env, subscription_id: u64, auto_renew: bool) {
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("subscription not found");
+
+        sub.holder.require_auth();
+        sub.auto_renew = auto_renew;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscription_id), &sub);
+    }
+
+    // ──────────────── INTERNAL HELPERS ────────────────
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        if *caller != admin {
+            panic!("caller is not admin");
+        }
+    }
+
+    fn get_tier_config_or_panic(env: &Env, tier: Tier) -> TierConfig {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TierConfig(tier))
+            .expect("tier not configured")
+    }
+
+    fn player_sub_id(env: &Env, player: &Address) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PlayerSub(player.clone()))
+    }
+
+    fn next_id(env: &Env) -> u64 {
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(1);
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        id
+    }
+}

--- a/contracts/puzzle_subscription_tier/src/tests.rs
+++ b/contracts/puzzle_subscription_tier/src/tests.rs
@@ -1,0 +1,404 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, String,
+};
+
+// ─────────────────────────────────────────────────────────
+// HELPERS
+// ─────────────────────────────────────────────────────────
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (Address, TokenClient<'a>) {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let addr = sac.address();
+    (addr.clone(), TokenClient::new(env, &addr))
+}
+
+struct TestEnv {
+    env: Env,
+    admin: Address,
+    player: Address,
+    contract_id: Address,
+    token_id: Address,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let player = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+
+        let (token_id, _token) = create_token(&env, &token_admin);
+        let asset_admin = StellarAssetClient::new(&env, &token_id);
+
+        let contract_id = env.register_contract(None, PuzzleSubscriptionTierContract);
+        let client = PuzzleSubscriptionTierContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &token_id);
+
+        // Fund player
+        asset_admin.mint(&player, &100_000);
+
+        TestEnv { env, admin, player, contract_id, token_id }
+    }
+
+    fn client(&self) -> PuzzleSubscriptionTierContractClient<'_> {
+        PuzzleSubscriptionTierContractClient::new(&self.env, &self.contract_id)
+    }
+
+    fn token(&self) -> TokenClient<'_> {
+        TokenClient::new(&self.env, &self.token_id)
+    }
+
+    fn asset_admin(&self) -> StellarAssetClient<'_> {
+        StellarAssetClient::new(&self.env, &self.token_id)
+    }
+}
+
+fn register_tiers(t: &TestEnv) {
+    let client = t.client();
+    let empty: soroban_sdk::Vec<String> = vec![&t.env];
+
+    client.set_tier_config(&t.admin, &Tier::Free, &0, &30, &1, &empty);
+
+    client.set_tier_config(
+        &t.admin,
+        &Tier::Pro,
+        &100,
+        &30,
+        &5,
+        &vec![&t.env, String::from_str(&t.env, "hints")],
+    );
+
+    client.set_tier_config(
+        &t.admin,
+        &Tier::Elite,
+        &200,
+        &30,
+        &10,
+        &vec![
+            &t.env,
+            String::from_str(&t.env, "hints"),
+            String::from_str(&t.env, "leaderboard"),
+        ],
+    );
+}
+
+// ─────────────────────────────────────────────────────────
+// TESTS
+// ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_subscribe_free_tier() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Free);
+    assert_eq!(sub_id, 1);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.holder, t.player);
+    assert_eq!(sub.tier, Tier::Free);
+    assert!(sub.expires_at > sub.started_at);
+
+    // No tokens charged for free tier.
+    assert_eq!(t.token().balance(&t.player), 100_000);
+}
+
+#[test]
+fn test_subscribe_pro_tier_charges_price() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+    assert_eq!(sub_id, 1);
+    assert_eq!(t.token().balance(&t.player), 100_000 - 100);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.tier, Tier::Pro);
+}
+
+#[test]
+fn test_subscribe_elite_tier() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Elite);
+    assert_eq!(t.token().balance(&t.player), 100_000 - 200);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.tier, Tier::Elite);
+}
+
+#[test]
+#[should_panic(expected = "existing subscription still active")]
+fn test_subscribe_fails_when_active_subscription_exists() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    client.subscribe(&t.player, &Tier::Pro);
+    // Second subscription should panic.
+    client.subscribe(&t.player, &Tier::Free);
+}
+
+#[test]
+fn test_subscribe_allowed_after_expiry() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    client.subscribe(&t.player, &Tier::Pro);
+
+    // Advance time past expiry (30 s in test mode).
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 31);
+
+    // Should succeed since previous subscription is expired.
+    let sub_id2 = client.subscribe(&t.player, &Tier::Free);
+    assert!(sub_id2 > 0);
+}
+
+#[test]
+fn test_renew_extends_expiry() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+    let sub_before = client.get_subscription(&sub_id);
+
+    // Enable auto-renew.
+    client.set_auto_renew(&sub_id, &true);
+
+    // Advance time (still within period).
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 10);
+
+    client.renew(&t.player, &sub_id);
+
+    let sub_after = client.get_subscription(&sub_id);
+    assert!(sub_after.expires_at > sub_before.expires_at);
+    // An extra 100 charged.
+    assert_eq!(t.token().balance(&t.player), 100_000 - 100 - 100);
+}
+
+#[test]
+fn test_renew_without_auto_renew_requires_holder() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    // auto_renew defaults to false.
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+
+    // Holder can renew themselves.
+    client.renew(&t.player, &sub_id);
+    let sub = client.get_subscription(&sub_id);
+    assert!(sub.expires_at > t.env.ledger().timestamp());
+}
+
+#[test]
+fn test_upgrade_proration() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    // Subscribe to Pro at t=0; period = 30 s, price = 100.
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+    let balance_after_sub = t.token().balance(&t.player);
+
+    // Advance to the midpoint (15 s remaining).
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 15);
+
+    // Upgrade to Elite (price = 200).
+    // remaining_value = 100 * 15 / 30 = 50
+    // charge = 200 - 50 = 150
+    client.upgrade(&sub_id, &Tier::Elite);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.tier, Tier::Elite);
+
+    let charged = balance_after_sub - t.token().balance(&t.player);
+    assert_eq!(charged, 150);
+
+    // Period reset to full 30 s from upgrade time.
+    let now = t.env.ledger().timestamp();
+    assert_eq!(sub.expires_at, now + 30);
+}
+
+#[test]
+fn test_upgrade_zero_charge_when_remaining_exceeds_new_price() {
+    // Edge case: if remaining_value >= new_price, charge = 0.
+    let t = TestEnv::new();
+    let client = t.client();
+    let empty: soroban_sdk::Vec<String> = vec![&t.env];
+
+    // Pro: price=1000, duration=30 days
+    client.set_tier_config(&t.admin, &Tier::Pro, &1000, &30, &5, &empty);
+    // Elite: price=100, duration=30 days (cheaper — tests the floor)
+    client.set_tier_config(&t.admin, &Tier::Elite, &100, &30, &10, &empty);
+
+    // Give player enough for Pro.
+    t.asset_admin().mint(&t.player, &900); // now has 100_900 total
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+
+    // Advance only 1 second; remaining_value = 1000 * 29 / 30 ≈ 966 > 100
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 1);
+
+    let balance_before_upgrade = t.token().balance(&t.player);
+    client.upgrade(&sub_id, &Tier::Elite);
+
+    // Charge capped at 0.
+    assert_eq!(t.token().balance(&t.player), balance_before_upgrade);
+}
+
+#[test]
+#[should_panic(expected = "can only upgrade to a higher tier")]
+fn test_upgrade_rejects_downgrade() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Elite);
+    client.upgrade(&sub_id, &Tier::Pro);
+}
+
+#[test]
+#[should_panic(expected = "subscription has expired")]
+fn test_upgrade_rejects_expired_subscription() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 31);
+
+    client.upgrade(&sub_id, &Tier::Elite);
+}
+
+#[test]
+fn test_cancel_disables_auto_renew() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+    client.set_auto_renew(&sub_id, &true);
+
+    client.cancel(&sub_id);
+
+    let sub = client.get_subscription(&sub_id);
+    assert!(!sub.auto_renew);
+    // Subscription is still active until expires_at.
+    assert!(sub.expires_at > t.env.ledger().timestamp());
+}
+
+#[test]
+fn test_has_access_active_subscription() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    client.subscribe(&t.player, &Tier::Pro);
+
+    assert!(client.has_access(&t.player, &Tier::Free));
+    assert!(client.has_access(&t.player, &Tier::Pro));
+    assert!(!client.has_access(&t.player, &Tier::Elite));
+}
+
+#[test]
+fn test_has_access_elite_passes_all_tiers() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    client.subscribe(&t.player, &Tier::Elite);
+
+    assert!(client.has_access(&t.player, &Tier::Free));
+    assert!(client.has_access(&t.player, &Tier::Pro));
+    assert!(client.has_access(&t.player, &Tier::Elite));
+}
+
+#[test]
+fn test_has_access_returns_false_for_expired_subscription() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    client.subscribe(&t.player, &Tier::Pro);
+
+    // Advance past expiry.
+    t.env.ledger().set_timestamp(t.env.ledger().timestamp() + 31);
+
+    assert!(!client.has_access(&t.player, &Tier::Pro));
+    assert!(!client.has_access(&t.player, &Tier::Elite));
+}
+
+#[test]
+fn test_has_access_no_subscription_only_free() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    // No subscription at all.
+    assert!(client.has_access(&t.player, &Tier::Free));
+    assert!(!client.has_access(&t.player, &Tier::Pro));
+    assert!(!client.has_access(&t.player, &Tier::Elite));
+}
+
+#[test]
+fn test_tier_config_update() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let empty: soroban_sdk::Vec<String> = vec![&t.env];
+
+    // Update Pro tier price.
+    client.set_tier_config(&t.admin, &Tier::Pro, &500, &60, &7, &empty);
+
+    let cfg = client.get_tier_config(&Tier::Pro);
+    assert_eq!(cfg.price, 500);
+    assert_eq!(cfg.duration_days, 60);
+    assert_eq!(cfg.puzzle_access_level, 7);
+}
+
+#[test]
+fn test_subscription_id_increments() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let player2 = Address::generate(&t.env);
+    let player3 = Address::generate(&t.env);
+    t.asset_admin().mint(&player2, &100_000);
+    t.asset_admin().mint(&player3, &100_000);
+
+    let id1 = client.subscribe(&player2, &Tier::Free);
+    let id2 = client.subscribe(&player3, &Tier::Free);
+
+    assert_eq!(id2, id1 + 1);
+}
+
+#[test]
+fn test_get_player_subscription_id() {
+    let t = TestEnv::new();
+    register_tiers(&t);
+    let client = t.client();
+
+    let unrelated = Address::generate(&t.env);
+
+    let sub_id = client.subscribe(&t.player, &Tier::Pro);
+
+    assert_eq!(client.get_player_subscription_id(&t.player), Some(sub_id));
+    assert_eq!(client.get_player_subscription_id(&unrelated), None);
+}


### PR DESCRIPTION
## feat: Tiered Puzzle Access Subscription Contract

Closes #168

### Summary

Implements `contracts/puzzle_subscription_tier` — a fully on-chain tiered subscription system for puzzle access control with three tiers: **Free**, **Pro**, and **Elite**.

---

### Changes

**New contract:** `contracts/puzzle_subscription_tier/`

| File | Description |
|------|-------------|
| `src/lib.rs` | Full contract implementation |
| `src/tests.rs` | 19 unit tests |
| `Cargo.toml` | Package manifest |

**Modified:** `Cargo.toml` — added `contracts/puzzle_subscription_tier` to workspace members.

---

### Implementation Details

#### Data Structures

**`Subscription`**
```rust
pub struct Subscription {
    pub holder: Address,
    pub tier: Tier,          // Free | Pro | Elite
    pub started_at: u64,
    pub expires_at: u64,
    pub auto_renew: bool,
}
```

**`TierConfig`** (admin-configurable per tier)
```rust
pub struct TierConfig {
    pub tier: Tier,
    pub price: i128,
    pub duration_days: u64,
    pub puzzle_access_level: u32,
    pub feature_flags: Vec<String>,
}
```

#### Entry Points

| Function | Description |
|----------|-------------|
| `initialize(admin, payment_token)` | One-time setup |
| `set_tier_config(admin, tier, ...)` | Admin configures tier pricing/features |
| `subscribe(player, tier) → u64` | Subscribe (or re-subscribe after expiry); charges tier price |
| `renew(caller, subscription_id)` | Extends `expires_at` by one full period; anyone may call when `auto_renew = true` |
| `upgrade(subscription_id, new_tier)` | Prorates remaining value of current tier; charges only the difference |
| `cancel(subscription_id)` | Sets `auto_renew = false`; subscription runs until `expires_at` |
| `has_access(player, required_tier) → bool` | Trustless on-chain access gate usable by other contracts |
| `set_auto_renew(subscription_id, bool)` | Toggle auto-renewal |
| `get_subscription(id)` | Query subscription record |
| `get_tier_config(tier)` | Query tier configuration |
| `get_player_subscription_id(player)` | Lookup a player's current subscription id |

#### Proration Logic

On `upgrade`, the unused value of the current subscription is calculated as:

```
remaining_value = old_price × remaining_seconds / period_seconds
charge = max(0, new_price − remaining_value)
```

The subscription period is reset to a full period of the new tier from the moment of upgrade.

#### Events Emitted

| Event | Data |
|-------|------|
| `subscribed` | `(subscription_id, tier)` |
| `renewed` | `(subscription_id, new_expires_at)` |
| `upgraded` | `(subscription_id, old_tier, new_tier, charge)` |
| `cancelled` | `subscription_id` |

#### Expired Subscription Behaviour

- `has_access` returns `false` for any tier above `Free` when the subscription is expired
- `upgrade` panics on expired subscriptions
- `subscribe` allows a new subscription once the previous one has expired

---

### Tests (19 passing)

```
test tests::test_cancel_disables_auto_renew                           ... ok
test tests::test_get_player_subscription_id                           ... ok
test tests::test_has_access_active_subscription                       ... ok
test tests::test_has_access_elite_passes_all_tiers                    ... ok
test tests::test_has_access_no_subscription_only_free                 ... ok
test tests::test_has_access_returns_false_for_expired_subscription    ... ok
test tests::test_renew_extends_expiry                                 ... ok
test tests::test_renew_without_auto_renew_requires_holder             ... ok
test tests::test_subscribe_allowed_after_expiry                       ... ok
test tests::test_subscribe_elite_tier                                 ... ok
test tests::test_subscribe_fails_when_active_subscription_exists      ... ok
test tests::test_subscribe_free_tier                                  ... ok
test tests::test_subscribe_pro_tier_charges_price                     ... ok
test tests::test_subscription_id_increments                           ... ok
test tests::test_tier_config_update                                   ... ok
test tests::test_upgrade_proration                                    ... ok
test tests::test_upgrade_rejects_downgrade                            ... ok
test tests::test_upgrade_rejects_expired_subscription                 ... ok
test tests::test_upgrade_zero_charge_when_remaining_exceeds_new_price ... ok

test result: ok. 19 passed; 0 failed; 0 ignored
```

---

### Acceptance Criteria

- [x] Tiers configurable with different prices and features via `set_tier_config`
- [x] Proration applied correctly on upgrades
- [x] `has_access` queryable on-chain by other contracts
- [x] Expired subscriptions reject access checks
- [x] `subscribe`, `renew`, `upgrade` (with proration), `cancel`, and access gate tests all pass
