### PR TITLE
feat: Add NFT staking contract with passive per-ledger rewards (#177)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "contracts/achievement_collection",
   "contracts/achievement_nft",
   "contracts/fractional_nft",
+  "contracts/nft_staking",
   "contracts/achievement_sets",
   "contracts/auction",
   "contracts/battle_pass",

--- a/contracts/nft_staking/Cargo.toml
+++ b/contracts/nft_staking/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nft-staking"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+reward-token = { path = "../reward_token" }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/nft_staking/README.md
+++ b/contracts/nft_staking/README.md
@@ -1,0 +1,37 @@
+# NFT Staking & Passive Rewards (`nft-staking`)
+
+Stake achievement NFTs to accrue passive token rewards **per ledger**.
+
+## How it works
+
+- **Locking:** `stake` transfers the NFT into the staking contract address (the NFT is not transferable/burnable by the original owner while staked).
+- **Accrual:** rewards accrue as:
+  - `(current_ledger - last_claim_ledger) * tokens_per_ledger`
+- **Claiming:** `claim_rewards` mints rewards to the staker without requiring an unstake.
+- **Unstaking:** `unstake` requires a **48h minimum** stake duration and auto-claims pending rewards.
+
+## Admin setup
+
+This contract expects two layers of configuration:
+
+1. **Reward rate per rarity tier**
+   - `set_rarity_config(admin, rarity, tokens_per_ledger)`
+2. **Rarity tier per NFT token id**
+   - `set_token_rarity(admin, token_id, rarity)`
+
+> Note: rewards are paid via the `reward_token` contract using `mint(minter=staking_contract, ...)`. The `reward_token` admin must authorize the staking contract as a minter (call `authorize_minter(staking_contract_id)` on the reward token contract).
+
+## Public functions
+
+- `stake(staker, token_id)`
+- `claim_rewards(staker, token_id)`
+- `unstake(staker, token_id)` (48h minimum)
+- `pending_rewards(token_id)` (view)
+- `get_position(token_id)` (view)
+
+## Events
+
+- `NFTStaked(token_id, staker)`
+- `NFTUnstaked(token_id, staker)`
+- `RewardsClaimed(token_id, (staker, amount))`
+

--- a/contracts/nft_staking/src/lib.rs
+++ b/contracts/nft_staking/src/lib.rs
@@ -1,0 +1,360 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
+
+// ─────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────
+
+const MIN_STAKE_SECONDS: u64 = 48 * 60 * 60; // 48h
+
+// ─────────────────────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum NftStakingError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    PositionAlreadyExists = 4,
+    PositionNotFound = 5,
+    NotTokenOwner = 6,
+    UnstakeTooEarly = 7,
+    InvalidRewardRate = 8,
+    RarityNotConfigured = 9,
+    InvalidTokenRarity = 10,
+}
+
+// ─────────────────────────────────────────────────────────────
+// Data Types
+// ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Config {
+    pub admin: Address,
+    pub nft_contract: Address,
+    pub reward_token: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NFTStakePosition {
+    pub staker: Address,
+    pub token_id: u32,
+    pub rarity: u32,
+    pub staked_at: u64,
+    pub last_claim_ledger: u32,
+    pub total_claimed: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RarityConfig {
+    pub rarity: u32,
+    pub tokens_per_ledger: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PositionView {
+    pub position: NFTStakePosition,
+    pub pending_rewards: i128,
+    pub days_staked: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Position(u32),      // token_id => NFTStakePosition
+    RarityConfig(u32),  // rarity => RarityConfig
+    TokenRarity(u32),   // token_id => rarity
+}
+
+// ─────────────────────────────────────────────────────────────
+// External Clients (minimal interfaces)
+// ─────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contractclient(name = "AchievementNFTClient")]
+pub trait AchievementNFT {
+    fn owner_of(env: Env, token_id: u32) -> Address;
+    fn transfer(env: Env, from: Address, to: Address, token_id: u32);
+}
+
+#[soroban_sdk::contractclient(name = "RewardTokenClient")]
+pub trait RewardToken {
+    fn mint(env: Env, minter: Address, to: Address, amount: i128);
+}
+
+// ─────────────────────────────────────────────────────────────
+// Contract
+// ─────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct NftStakingContract;
+
+#[contractimpl]
+impl NftStakingContract {
+    // ───────────── Initialization ─────────────
+
+    pub fn initialize(env: Env, admin: Address, nft_contract: Address, reward_token: Address) {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Config) {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::AlreadyInitialized);
+        }
+
+        let cfg = Config {
+            admin,
+            nft_contract,
+            reward_token,
+        };
+
+        env.storage().instance().set(&DataKey::Config, &cfg);
+    }
+
+    // ───────────── Admin: Rarity config ─────────────
+
+    pub fn set_rarity_config(env: Env, admin: Address, rarity: u32, tokens_per_ledger: i128) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+
+        if tokens_per_ledger <= 0 {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::InvalidRewardRate);
+        }
+
+        let cfg = RarityConfig {
+            rarity,
+            tokens_per_ledger,
+        };
+
+        let key = DataKey::RarityConfig(rarity);
+        env.storage().persistent().set(&key, &cfg);
+        env.storage().persistent().extend_ttl(&key, 100_000, 500_000);
+    }
+
+    /// Configure the rarity tier for a specific token id (admin only).
+    ///
+    /// This enables `stake(token_id)` to record the correct rarity without
+    /// trusting user-supplied rarity values.
+    pub fn set_token_rarity(env: Env, admin: Address, token_id: u32, rarity: u32) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::RarityConfig(rarity))
+        {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::RarityNotConfigured);
+        }
+
+        let key = DataKey::TokenRarity(token_id);
+        env.storage().persistent().set(&key, &rarity);
+        env.storage().persistent().extend_ttl(&key, 100_000, 500_000);
+    }
+
+    // ───────────── Core: stake/claim/unstake ─────────────
+
+    /// Stake an NFT and begin accruing rewards per-ledger.
+    ///
+    /// Locks the NFT by transferring it into this contract.
+    pub fn stake(env: Env, staker: Address, token_id: u32) {
+        staker.require_auth();
+
+        let cfg = Self::load_config(&env);
+        let pos_key = DataKey::Position(token_id);
+        if env.storage().persistent().has(&pos_key) {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::PositionAlreadyExists);
+        }
+
+        // Ensure the caller owns the NFT before transferring it in.
+        let nft = AchievementNFTClient::new(&env, &cfg.nft_contract);
+        let owner = nft.owner_of(&token_id);
+        if owner != staker {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::NotTokenOwner);
+        }
+
+        // Resolve rarity for this token (must be set by admin).
+        let rarity: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TokenRarity(token_id))
+            .unwrap_or_else(|| soroban_sdk::panic_with_error!(&env, NftStakingError::InvalidTokenRarity));
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::RarityConfig(rarity))
+        {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::RarityNotConfigured);
+        }
+
+        // Transfer the NFT into this contract (lock).
+        nft.transfer(&staker, &env.current_contract_address(), &token_id);
+
+        let position = NFTStakePosition {
+            staker: staker.clone(),
+            token_id,
+            rarity,
+            staked_at: env.ledger().timestamp(),
+            last_claim_ledger: env.ledger().sequence(),
+            total_claimed: 0,
+        };
+
+        env.storage().persistent().set(&pos_key, &position);
+        env.storage().persistent().extend_ttl(&pos_key, 100_000, 500_000);
+
+        env.events()
+            .publish((Symbol::new(&env, "NFTStaked"), token_id), staker);
+    }
+
+    /// Claim currently accrued rewards for a staked NFT.
+    pub fn claim_rewards(env: Env, staker: Address, token_id: u32) -> i128 {
+        staker.require_auth();
+
+        let mut pos = Self::load_position(&env, token_id);
+        if pos.staker != staker {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::Unauthorized);
+        }
+
+        let pending = Self::calculate_pending_rewards(&env, &pos);
+        pos.last_claim_ledger = env.ledger().sequence();
+
+        if pending > 0 {
+            pos.total_claimed = pos
+                .total_claimed
+                .checked_add(pending)
+                .unwrap_or_else(|| panic!("overflow"));
+
+            let cfg = Self::load_config(&env);
+            let rewards = RewardTokenClient::new(&env, &cfg.reward_token);
+            let minter = env.current_contract_address();
+            rewards.mint(&minter, &pos.staker, &pending);
+
+            env.events()
+                .publish((Symbol::new(&env, "RewardsClaimed"), token_id), (pos.staker.clone(), pending));
+        }
+
+        let pos_key = DataKey::Position(token_id);
+        env.storage().persistent().set(&pos_key, &pos);
+        env.storage().persistent().extend_ttl(&pos_key, 100_000, 500_000);
+
+        pending
+    }
+
+    /// Unstake an NFT after the 48h minimum and automatically claim any pending rewards.
+    pub fn unstake(env: Env, staker: Address, token_id: u32) -> i128 {
+        staker.require_auth();
+
+        let cfg = Self::load_config(&env);
+        let pos = Self::load_position(&env, token_id);
+
+        if pos.staker != staker {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::Unauthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < pos.staked_at || now - pos.staked_at < MIN_STAKE_SECONDS {
+            soroban_sdk::panic_with_error!(&env, NftStakingError::UnstakeTooEarly);
+        }
+
+        // Claim pending rewards as part of unstake.
+        let pending = Self::calculate_pending_rewards(&env, &pos);
+        if pending > 0 {
+            let rewards = RewardTokenClient::new(&env, &cfg.reward_token);
+            let minter = env.current_contract_address();
+            rewards.mint(&minter, &pos.staker, &pending);
+
+            env.events()
+                .publish((Symbol::new(&env, "RewardsClaimed"), token_id), (pos.staker.clone(), pending));
+        }
+
+        // Return NFT to staker.
+        let nft = AchievementNFTClient::new(&env, &cfg.nft_contract);
+        nft.transfer(
+            &env.current_contract_address(),
+            &pos.staker,
+            &token_id,
+        );
+
+        env.storage().persistent().remove(&DataKey::Position(token_id));
+        env.events()
+            .publish((Symbol::new(&env, "NFTUnstaked"), token_id), pos.staker.clone());
+
+        pending
+    }
+
+    // ───────────── View functions ─────────────
+
+    /// Estimate pending rewards for a staked token id at the current ledger.
+    pub fn pending_rewards(env: Env, token_id: u32) -> i128 {
+        let pos = Self::load_position(&env, token_id);
+        Self::calculate_pending_rewards(&env, &pos)
+    }
+
+    /// Get stake details plus pending rewards and days staked.
+    pub fn get_position(env: Env, token_id: u32) -> PositionView {
+        let pos = Self::load_position(&env, token_id);
+        let pending = Self::calculate_pending_rewards(&env, &pos);
+        let now = env.ledger().timestamp();
+        let seconds = now.saturating_sub(pos.staked_at);
+        let days_staked = seconds / 86_400;
+
+        PositionView {
+            position: pos,
+            pending_rewards: pending,
+            days_staked,
+        }
+    }
+
+    // ───────────── Internal helpers ─────────────
+
+    fn load_config(env: &Env) -> Config {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, NftStakingError::NotInitialized))
+    }
+
+    fn require_admin(env: &Env, admin: &Address) {
+        let cfg = Self::load_config(env);
+        if &cfg.admin != admin {
+            soroban_sdk::panic_with_error!(env, NftStakingError::Unauthorized);
+        }
+    }
+
+    fn load_position(env: &Env, token_id: u32) -> NFTStakePosition {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Position(token_id))
+            .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, NftStakingError::PositionNotFound))
+    }
+
+    fn tokens_per_ledger(env: &Env, rarity: u32) -> i128 {
+        let cfg: RarityConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RarityConfig(rarity))
+            .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, NftStakingError::RarityNotConfigured));
+        cfg.tokens_per_ledger
+    }
+
+    fn calculate_pending_rewards(env: &Env, pos: &NFTStakePosition) -> i128 {
+        let current = env.ledger().sequence();
+        if current <= pos.last_claim_ledger {
+            return 0;
+        }
+
+        let ledgers = current - pos.last_claim_ledger;
+        let rate = Self::tokens_per_ledger(env, pos.rarity);
+
+        rate.checked_mul(ledgers as i128)
+            .unwrap_or_else(|| panic!("overflow"))
+    }
+}
+
+mod test;

--- a/contracts/nft_staking/src/test.rs
+++ b/contracts/nft_staking/src/test.rs
@@ -1,0 +1,272 @@
+#![cfg(test)]
+
+use super::*;
+use reward_token::{RewardToken as RewardTokenContract, RewardTokenClient as RewardTokenContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String,
+};
+
+// ─────────────────────────────────────────────────────────────
+// Mock NFT contract with rarity + transfer + burn restrictions
+// ─────────────────────────────────────────────────────────────
+
+#[contract]
+struct MockAchievementNft;
+
+#[contracttype]
+enum MockKey {
+    Admin,
+    Owner(u32),
+    Rarity(u32),
+}
+
+#[contractimpl]
+impl MockAchievementNft {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&MockKey::Admin, &admin);
+    }
+
+    pub fn mint(env: Env, admin: Address, to: Address, token_id: u32, rarity: u32) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&MockKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("not admin");
+        }
+
+        env.storage().persistent().set(&MockKey::Owner(token_id), &to);
+        env.storage().persistent().set(&MockKey::Rarity(token_id), &rarity);
+    }
+
+    pub fn owner_of(env: Env, token_id: u32) -> Address {
+        env.storage()
+            .persistent()
+            .get(&MockKey::Owner(token_id))
+            .unwrap()
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, token_id: u32) {
+        from.require_auth();
+        let owner = Self::owner_of(env.clone(), token_id);
+        if owner != from {
+            panic!("not owner");
+        }
+        env.storage().persistent().set(&MockKey::Owner(token_id), &to);
+    }
+
+    pub fn burn(env: Env, owner: Address, token_id: u32) {
+        owner.require_auth();
+        let current = Self::owner_of(env.clone(), token_id);
+        if current != owner {
+            panic!("not owner");
+        }
+        env.storage().persistent().remove(&MockKey::Owner(token_id));
+        env.storage().persistent().remove(&MockKey::Rarity(token_id));
+    }
+}
+
+fn set_ledger(env: &Env, sequence: u32, timestamp: u64) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number = sequence;
+        li.timestamp = timestamp;
+    });
+}
+
+struct Setup {
+    env: Env,
+    admin: Address,
+    staker: Address,
+    other: Address,
+    staking_id: Address,
+    staking: NftStakingContractClient<'static>,
+    nft: MockAchievementNftClient<'static>,
+    reward_token: RewardTokenContractClient<'static>,
+}
+
+fn setup() -> Setup {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let staker = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    // Reward token
+    let reward_token_id = env.register_contract(None, RewardTokenContract);
+    let reward_token = RewardTokenContractClient::new(&env, &reward_token_id);
+    reward_token.initialize(
+        &admin,
+        &String::from_str(&env, "Reward"),
+        &String::from_str(&env, "RWD"),
+        &6u32,
+    );
+
+    // Mock NFT
+    let nft_id = env.register_contract(None, MockAchievementNft);
+    let nft = MockAchievementNftClient::new(&env, &nft_id);
+    nft.initialize(&admin);
+
+    // Staking contract
+    let staking_id = env.register_contract(None, NftStakingContract);
+    let staking = NftStakingContractClient::new(&env, &staking_id);
+    staking.initialize(&admin, &nft_id, &reward_token_id);
+
+    // Allow staking contract to mint rewards
+    reward_token.authorize_minter(&staking_id);
+
+    Setup {
+        env,
+        admin,
+        staker,
+        other,
+        staking_id,
+        staking,
+        nft,
+        reward_token,
+    }
+}
+
+#[test]
+fn stake_locks_nft_and_records_position() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &5i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    assert_eq!(s.nft.owner_of(&1u32), s.staker);
+
+    s.staking.stake(&s.staker, &1u32);
+
+    // NFT is locked in contract while staked.
+    assert_eq!(s.nft.owner_of(&1u32), s.staking_id);
+
+    let view = s.staking.get_position(&1u32);
+    assert_eq!(view.position.token_id, 1);
+    assert_eq!(view.position.staker, s.staker);
+    assert_eq!(view.position.rarity, 1);
+    assert_eq!(view.position.last_claim_ledger, 10);
+    assert_eq!(view.pending_rewards, 0);
+    assert_eq!(view.days_staked, 0);
+}
+
+#[test]
+#[should_panic(expected = "not owner")]
+fn transfer_blocked_while_staked() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &5i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.staking.stake(&s.staker, &1u32);
+
+    // Staker is no longer the owner, so transfer must fail.
+    s.nft.transfer(&s.staker, &s.other, &1u32);
+}
+
+#[test]
+#[should_panic(expected = "not owner")]
+fn burn_blocked_while_staked() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &5i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.staking.stake(&s.staker, &1u32);
+
+    // Staker is no longer the owner, so burn must fail.
+    s.nft.burn(&s.staker, &1u32);
+}
+
+#[test]
+fn rewards_accrue_per_ledger_and_claim_without_unstaking() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &10i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.staking.stake(&s.staker, &1u32);
+
+    set_ledger(&s.env, 15, 1_050);
+    assert_eq!(s.staking.pending_rewards(&1u32), 50);
+
+    let claimed1 = s.staking.claim_rewards(&s.staker, &1u32);
+    assert_eq!(claimed1, 50);
+    assert_eq!(s.reward_token.balance(&s.staker), 50);
+
+    // Claim again later without unstaking.
+    set_ledger(&s.env, 18, 1_100);
+    assert_eq!(s.staking.pending_rewards(&1u32), 30);
+
+    let claimed2 = s.staking.claim_rewards(&s.staker, &1u32);
+    assert_eq!(claimed2, 30);
+    assert_eq!(s.reward_token.balance(&s.staker), 80);
+
+    let view = s.staking.get_position(&1u32);
+    assert_eq!(view.pending_rewards, 0);
+    assert_eq!(view.position.total_claimed, 80);
+    assert_eq!(view.position.last_claim_ledger, 18);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn unstake_before_48h_rejected() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &2i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.staking.stake(&s.staker, &1u32);
+
+    set_ledger(&s.env, 11, 1_000 + MIN_STAKE_SECONDS - 1);
+    s.staking.unstake(&s.staker, &1u32);
+}
+
+#[test]
+fn unstake_after_48h_returns_nft_and_claims_rewards() {
+    let s = setup();
+    set_ledger(&s.env, 10, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &2i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.staking.stake(&s.staker, &1u32);
+
+    set_ledger(&s.env, 20, 1_000 + MIN_STAKE_SECONDS + 1);
+
+    let pending = s.staking.unstake(&s.staker, &1u32);
+    assert_eq!(pending, 20); // (20 - 10) * 2
+    assert_eq!(s.reward_token.balance(&s.staker), 20);
+    assert_eq!(s.nft.owner_of(&1u32), s.staker);
+}
+
+#[test]
+fn rarity_rate_differences_affect_rewards() {
+    let s = setup();
+    set_ledger(&s.env, 100, 1_000);
+
+    s.staking.set_rarity_config(&s.admin, &1u32, &5i128);
+    s.staking.set_rarity_config(&s.admin, &2u32, &20i128);
+    s.staking.set_token_rarity(&s.admin, &1u32, &1u32);
+    s.staking.set_token_rarity(&s.admin, &2u32, &2u32);
+
+    s.nft.mint(&s.admin, &s.staker, &1u32, &1u32);
+    s.nft.mint(&s.admin, &s.staker, &2u32, &2u32);
+    s.staking.stake(&s.staker, &1u32);
+    s.staking.stake(&s.staker, &2u32);
+
+    set_ledger(&s.env, 110, 1_050);
+
+    let p1 = s.staking.pending_rewards(&1u32);
+    let p2 = s.staking.pending_rewards(&2u32);
+    assert_eq!(p1, 50);  // (110 - 100) * 5
+    assert_eq!(p2, 200); // (110 - 100) * 20
+}

--- a/deploy_nft_staking.sh
+++ b/deploy_nft_staking.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# NFT Staking Contract Deployment Script (Testnet)
+
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTNET_RPC="https://soroban-testnet.stellar.org"
+TESTNET_NETWORK="Test SDF Network ; September 2015"
+ROOT_DIR="$(dirname "$0")"
+WASM_PATH="$ROOT_DIR/.stellar-artifacts/nft_staking.wasm"
+
+print_status() {
+  echo -e "${BLUE}➜${NC} $1"
+}
+
+print_success() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+if ! command -v stellar &> /dev/null; then
+  echo -e "${YELLOW}Stellar CLI not found. Install it first.${NC}"
+  exit 1
+fi
+
+if [ -z "$SOURCE_ACCOUNT" ]; then
+  read -p "Enter SOURCE_ACCOUNT: " SOURCE_ACCOUNT
+fi
+
+if [ -z "$NFT_CONTRACT" ]; then
+  read -p "Enter NFT_CONTRACT address: " NFT_CONTRACT
+fi
+
+if [ -z "$REWARD_TOKEN" ]; then
+  read -p "Enter REWARD_TOKEN address: " REWARD_TOKEN
+fi
+
+if [ -z "$SOURCE_ACCOUNT" ] || [ -z "$NFT_CONTRACT" ] || [ -z "$REWARD_TOKEN" ]; then
+  echo "Missing SOURCE_ACCOUNT, NFT_CONTRACT, or REWARD_TOKEN."
+  exit 1
+fi
+
+print_status "Checking testnet network configuration..."
+if ! stellar network ls | grep -q "testnet"; then
+  stellar network add testnet \
+    --rpc-url "$TESTNET_RPC" \
+    --network-passphrase "$TESTNET_NETWORK"
+fi
+print_success "Network is ready"
+
+DEPLOYER_ADDRESS=$(stellar keys address "$SOURCE_ACCOUNT")
+print_status "Deployer address: $DEPLOYER_ADDRESS"
+
+print_status "Building nft_staking wasm..."
+cd "$ROOT_DIR"
+stellar contract build --package nft-staking --profile release --out-dir .stellar-artifacts
+print_success "Build complete"
+
+if [ ! -f "$WASM_PATH" ]; then
+  echo "❌ Build failed - WASM file not found at $WASM_PATH"
+  exit 1
+fi
+
+print_status "Deploying nft_staking..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --source "$SOURCE_ACCOUNT" \
+  --network testnet)
+print_success "Deployed: $CONTRACT_ID"
+
+print_status "Initializing contract..."
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$SOURCE_ACCOUNT" \
+  --network testnet \
+  -- initialize \
+  --admin "$DEPLOYER_ADDRESS" \
+  --nft-contract "$NFT_CONTRACT" \
+  --reward-token "$REWARD_TOKEN"
+print_success "Initialized"
+
+echo ""
+echo "Contract ID: $CONTRACT_ID"
+echo ""
+echo "Next steps:"
+echo "1) Authorize this staking contract as a minter on the reward token contract:"
+echo "   stellar contract invoke --id $REWARD_TOKEN --source $SOURCE_ACCOUNT --network testnet \\"
+echo "     -- authorize_minter --minter $CONTRACT_ID"
+echo ""
+echo "2) Configure reward rates per rarity tier:"
+echo "   stellar contract invoke --id $CONTRACT_ID --source $SOURCE_ACCOUNT --network testnet \\"
+echo "     -- set_rarity_config --admin $DEPLOYER_ADDRESS --rarity 1 --tokens-per-ledger 5"
+echo ""
+echo "3) Map token ids to rarity tiers (required before staking):"
+echo "   stellar contract invoke --id $CONTRACT_ID --source $SOURCE_ACCOUNT --network testnet \\"
+echo "     -- set_token_rarity --admin $DEPLOYER_ADDRESS --token-id 1 --rarity 1"
+


### PR DESCRIPTION
Description:
This PR adds a new Soroban contract (`contracts/nft_staking`) that lets players stake achievement NFTs to earn passive token rewards over time. Reward rates are configured per rarity tier, rewards accrue per ledger, and can be claimed at any time without unstaking. Unstaking is blocked until a 48h minimum stake duration is met, and staked NFTs remain locked in the contract until unstaked.

Key changes:
- New `nft-staking` contract: stake/claim/unstake, pending rewards, position view, events (`NFTStaked`, `NFTUnstaked`, `RewardsClaimed`)
- Admin configuration: `set_rarity_config(rarity, tokens_per_ledger)` and `set_token_rarity(token_id, rarity)`
- Tests covering staking lock behavior, reward accrual + claiming, 48h unstake restriction, and rarity rate differences
- Added deployment helper `deploy_nft_staking.sh` and contract README

Notes:
- Reward distribution uses `reward_token.mint(minter=staking_contract, ...)`; the reward token admin must authorize the staking contract as a minter.
- Token rarities must be mapped via `set_token_rarity` before staking.

close #177 