### PR TITLE
feat: add conditional milestone reward contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
   "contracts/puzzle_subscription_tier",
   "contracts/airdrop_merkle_claim",
   "contracts/nft_trait_marketplace",
+  "contracts/conditional_reward",
 ]
 
 [workspace.dependencies]

--- a/contracts/conditional_reward/Cargo.toml
+++ b/contracts/conditional_reward/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "conditional_reward"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/conditional_reward/src/lib.rs
+++ b/contracts/conditional_reward/src/lib.rs
@@ -1,0 +1,528 @@
+#![no_std]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal, Map, Symbol,
+    TryFromVal, Val, Vec,
+};
+
+#[cfg(not(test))]
+const DAY_SECONDS: u64 = 86_400;
+#[cfg(test)]
+const DAY_SECONDS: u64 = 1;
+
+const KEY_CONTRACT: Symbol = symbol_short!("contract");
+const KEY_TOKEN_ID: Symbol = symbol_short!("token_id");
+const KEY_MIN: Symbol = symbol_short!("min");
+const KEY_DAYS: Symbol = symbol_short!("days");
+const KEY_TIER: Symbol = symbol_short!("tier");
+const KEY_ACT_TYPE: Symbol = symbol_short!("activity");
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConditionType {
+    NftHeld,
+    SolveCountGte,
+    RegistrationAgeGte,
+    TierGte,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Condition {
+    pub condition_type: ConditionType,
+    pub params: Map<Symbol, Val>,
+    pub or_group: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FailedCondition {
+    pub index: u32,
+    pub condition_type: ConditionType,
+    pub or_group: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneReward {
+    pub id: u64,
+    pub reward_amount: i128,
+    pub conditions: Vec<Condition>,
+    pub claimants: Vec<Address>,
+    pub max_claims: u32,
+    pub active: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardView {
+    pub id: u64,
+    pub reward_amount: i128,
+    pub conditions: Vec<Condition>,
+    pub claims_remaining: u32,
+    pub active: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    Token,
+    NextRewardId,
+    Reward(u64),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum SubscriptionTier {
+    Free = 0,
+    Pro = 1,
+    Elite = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SocialLinksView {
+    pub twitter: Option<soroban_sdk::String>,
+    pub discord: Option<soroban_sdk::String>,
+    pub github: Option<soroban_sdk::String>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerIdentityView {
+    pub address: Address,
+    pub username: soroban_sdk::String,
+    pub avatar_hash: Option<soroban_sdk::String>,
+    pub bio_hash: Option<soroban_sdk::String>,
+    pub social_links: SocialLinksView,
+    pub registered_at: u64,
+    pub verified: bool,
+}
+
+#[contract]
+pub struct ConditionalRewardContract;
+
+#[contractimpl]
+impl ConditionalRewardContract {
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+        admin.require_auth();
+
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Token, &token);
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextRewardId, &1u64);
+    }
+
+    pub fn create_reward(
+        env: Env,
+        admin: Address,
+        conditions: Vec<Condition>,
+        reward_amount: i128,
+        max_claims: u32,
+    ) -> u64 {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if reward_amount <= 0 {
+            panic!("reward amount must be positive");
+        }
+        if max_claims == 0 {
+            panic!("max claims must be positive");
+        }
+        if conditions.is_empty() {
+            panic!("conditions required");
+        }
+
+        for condition in conditions.iter() {
+            Self::validate_condition(&env, &condition);
+        }
+
+        let total_funding = reward_amount
+            .checked_mul(max_claims as i128)
+            .unwrap_or_else(|| panic!("funding overflow"));
+        let token = Self::token(&env);
+        token::Client::new(&env, &token).transfer(
+            &admin,
+            &env.current_contract_address(),
+            &total_funding,
+        );
+
+        let reward_id = Self::next_reward_id(&env);
+        let reward = MilestoneReward {
+            id: reward_id,
+            reward_amount,
+            conditions,
+            claimants: Vec::new(&env),
+            max_claims,
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reward(reward_id), &reward);
+        reward_id
+    }
+
+    pub fn check_eligibility(
+        env: Env,
+        reward_id: u64,
+        player: Address,
+    ) -> (bool, Vec<FailedCondition>) {
+        let reward = Self::get_reward_internal(&env, reward_id);
+        Self::evaluate_reward(&env, &reward, &player)
+    }
+
+    pub fn claim(env: Env, reward_id: u64, player: Address) {
+        player.require_auth();
+
+        let mut reward = Self::get_reward_internal(&env, reward_id);
+        if !reward.active {
+            panic!("reward inactive");
+        }
+        if reward.claimants.contains(&player) {
+            panic!("player already claimed");
+        }
+        if reward.claimants.len() >= reward.max_claims {
+            panic!("max claims reached");
+        }
+
+        let (eligible, failed) = Self::evaluate_reward(&env, &reward, &player);
+        if !eligible {
+            if !failed.is_empty() {
+                panic!("player not eligible");
+            }
+            panic!("eligibility check failed");
+        }
+
+        token::Client::new(&env, &Self::token(&env)).transfer(
+            &env.current_contract_address(),
+            &player,
+            &reward.reward_amount,
+        );
+
+        reward.claimants.push_back(player.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reward(reward_id), &reward);
+
+        env.events().publish(
+            (Symbol::new(&env, "RewardClaimed"), reward_id, player),
+            reward.reward_amount,
+        );
+    }
+
+    pub fn deactivate_reward(env: Env, admin: Address, reward_id: u64) -> i128 {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let mut reward = Self::get_reward_internal(&env, reward_id);
+        if !reward.active {
+            panic!("reward already inactive");
+        }
+
+        reward.active = false;
+        let claims_remaining = reward.max_claims.saturating_sub(reward.claimants.len());
+        let refund_amount = reward
+            .reward_amount
+            .checked_mul(claims_remaining as i128)
+            .unwrap_or_else(|| panic!("refund overflow"));
+
+        if refund_amount > 0 {
+            token::Client::new(&env, &Self::token(&env)).transfer(
+                &env.current_contract_address(),
+                &admin,
+                &refund_amount,
+            );
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reward(reward_id), &reward);
+        env.events()
+            .publish((Symbol::new(&env, "RewardDeactivated"), reward_id), admin);
+
+        refund_amount
+    }
+
+    pub fn get_reward(env: Env, reward_id: u64) -> RewardView {
+        let reward = Self::get_reward_internal(&env, reward_id);
+        RewardView {
+            id: reward.id,
+            reward_amount: reward.reward_amount,
+            conditions: reward.conditions,
+            claims_remaining: reward.max_claims.saturating_sub(reward.claimants.len()),
+            active: reward.active,
+        }
+    }
+
+    fn evaluate_reward(
+        env: &Env,
+        reward: &MilestoneReward,
+        player: &Address,
+    ) -> (bool, Vec<FailedCondition>) {
+        let mut results = Vec::new(env);
+        for condition in reward.conditions.iter() {
+            results.push_back(Self::evaluate_condition(env, &condition, player));
+        }
+
+        let mut failed = Vec::new(env);
+        let mut eligible = true;
+        let mut index: u32 = 0;
+        while index < reward.conditions.len() {
+            let condition = reward.conditions.get(index).unwrap();
+            let passed = results.get(index).unwrap();
+
+            if condition.or_group == 0 {
+                if !passed {
+                    eligible = false;
+                    failed.push_back(FailedCondition {
+                        index,
+                        condition_type: condition.condition_type,
+                        or_group: 0,
+                    });
+                }
+            } else if !Self::group_satisfied(reward, &results, condition.or_group) {
+                eligible = false;
+                failed.push_back(FailedCondition {
+                    index,
+                    condition_type: condition.condition_type,
+                    or_group: condition.or_group,
+                });
+            }
+
+            index += 1;
+        }
+
+        (eligible, failed)
+    }
+
+    fn group_satisfied(reward: &MilestoneReward, results: &Vec<bool>, group_id: u32) -> bool {
+        let mut index: u32 = 0;
+        while index < reward.conditions.len() {
+            let condition = reward.conditions.get(index).unwrap();
+            if condition.or_group == group_id && results.get(index).unwrap() {
+                return true;
+            }
+            index += 1;
+        }
+        false
+    }
+
+    fn evaluate_condition(env: &Env, condition: &Condition, player: &Address) -> bool {
+        match condition.condition_type {
+            ConditionType::NftHeld => {
+                let nft_contract = Self::get_param::<Address>(env, &condition.params, KEY_CONTRACT)
+                    .unwrap_or_else(|| panic!("missing nft contract"));
+                let token_id = Self::get_param::<u32>(env, &condition.params, KEY_TOKEN_ID)
+                    .unwrap_or_else(|| panic!("missing token id"));
+                let result = env.try_invoke_contract::<Address, soroban_sdk::Error>(
+                    &nft_contract,
+                    &symbol_short!("owner_of"),
+                    soroban_sdk::vec![env, token_id.into_val(env)],
+                );
+
+                matches!(result, Ok(Ok(owner)) if owner == *player)
+            }
+            ConditionType::SolveCountGte => {
+                let proof_contract =
+                    Self::get_param::<Address>(env, &condition.params, KEY_CONTRACT)
+                        .unwrap_or_else(|| panic!("missing proof contract"));
+                let minimum = Self::get_param::<u32>(env, &condition.params, KEY_MIN)
+                    .unwrap_or_else(|| panic!("missing solve threshold"));
+                let activity_type =
+                    Self::get_param::<u32>(env, &condition.params, KEY_ACT_TYPE).unwrap_or(0);
+
+                let result = env.try_invoke_contract::<u32, soroban_sdk::Error>(
+                    &proof_contract,
+                    &Symbol::new(env, "get_activity_count"),
+                    soroban_sdk::vec![
+                        env,
+                        player.clone().into_val(env),
+                        activity_type.into_val(env),
+                    ],
+                );
+
+                matches!(result, Ok(Ok(count)) if count >= minimum)
+            }
+            ConditionType::RegistrationAgeGte => {
+                let identity_contract =
+                    Self::get_param::<Address>(env, &condition.params, KEY_CONTRACT)
+                        .unwrap_or_else(|| panic!("missing identity contract"));
+                let minimum_days = Self::get_param::<u64>(env, &condition.params, KEY_DAYS)
+                    .unwrap_or_else(|| panic!("missing age threshold"));
+
+                let result = env
+                    .try_invoke_contract::<Option<PlayerIdentityView>, soroban_sdk::Error>(
+                        &identity_contract,
+                        &Symbol::new(env, "resolve_address"),
+                        soroban_sdk::vec![env, player.clone().into_val(env)],
+                    );
+
+                matches!(result, Ok(Ok(Some(identity))) if env.ledger().timestamp().saturating_sub(identity.registered_at) >= minimum_days.saturating_mul(DAY_SECONDS))
+            }
+            ConditionType::TierGte => {
+                let subscription_contract =
+                    Self::get_param::<Address>(env, &condition.params, KEY_CONTRACT)
+                        .unwrap_or_else(|| panic!("missing subscription contract"));
+                let tier_value = Self::get_param::<u32>(env, &condition.params, KEY_TIER)
+                    .unwrap_or_else(|| panic!("missing tier"));
+                let required_tier = SubscriptionTier::from_u32(tier_value)
+                    .unwrap_or_else(|| panic!("invalid tier"));
+
+                let result = env.try_invoke_contract::<bool, soroban_sdk::Error>(
+                    &subscription_contract,
+                    &Symbol::new(env, "has_access"),
+                    soroban_sdk::vec![
+                        env,
+                        player.clone().into_val(env),
+                        required_tier.into_val(env),
+                    ],
+                );
+
+                matches!(result, Ok(Ok(has_access)) if has_access)
+            }
+        }
+    }
+
+    fn validate_condition(env: &Env, condition: &Condition) {
+        if condition.or_group == u32::MAX {
+            panic!("invalid or group");
+        }
+
+        match condition.condition_type {
+            ConditionType::NftHeld => {
+                Self::require_param::<Address>(
+                    env,
+                    &condition.params,
+                    KEY_CONTRACT,
+                    "missing nft contract",
+                );
+                Self::require_param::<u32>(
+                    env,
+                    &condition.params,
+                    KEY_TOKEN_ID,
+                    "missing token id",
+                );
+            }
+            ConditionType::SolveCountGte => {
+                Self::require_param::<Address>(
+                    env,
+                    &condition.params,
+                    KEY_CONTRACT,
+                    "missing proof contract",
+                );
+                Self::require_param::<u32>(
+                    env,
+                    &condition.params,
+                    KEY_MIN,
+                    "missing solve threshold",
+                );
+                if Self::get_param::<u32>(env, &condition.params, KEY_ACT_TYPE).is_none() {
+                    let _ = 0u32;
+                }
+            }
+            ConditionType::RegistrationAgeGte => {
+                Self::require_param::<Address>(
+                    env,
+                    &condition.params,
+                    KEY_CONTRACT,
+                    "missing identity contract",
+                );
+                Self::require_param::<u64>(
+                    env,
+                    &condition.params,
+                    KEY_DAYS,
+                    "missing age threshold",
+                );
+            }
+            ConditionType::TierGte => {
+                Self::require_param::<Address>(
+                    env,
+                    &condition.params,
+                    KEY_CONTRACT,
+                    "missing subscription contract",
+                );
+                let tier_value =
+                    Self::require_param::<u32>(env, &condition.params, KEY_TIER, "missing tier");
+                if SubscriptionTier::from_u32(tier_value).is_none() {
+                    panic!("invalid tier");
+                }
+            }
+        }
+    }
+
+    fn require_param<T: TryFromVal<Env, Val>>(
+        env: &Env,
+        params: &Map<Symbol, Val>,
+        key: Symbol,
+        error: &str,
+    ) -> T {
+        Self::get_param(env, params, key).unwrap_or_else(|| panic!("{}", error))
+    }
+
+    fn get_param<T: TryFromVal<Env, Val>>(
+        env: &Env,
+        params: &Map<Symbol, Val>,
+        key: Symbol,
+    ) -> Option<T> {
+        let value = params.get(key)?;
+        T::try_from_val(env, &value).ok()
+    }
+
+    fn get_reward_internal(env: &Env, reward_id: u64) -> MilestoneReward {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reward(reward_id))
+            .unwrap_or_else(|| panic!("reward not found"))
+    }
+
+    fn next_reward_id(env: &Env) -> u64 {
+        let reward_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextRewardId)
+            .unwrap_or(1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextRewardId, &(reward_id + 1));
+        reward_id
+    }
+
+    fn assert_admin(env: &Env, admin: &Address) {
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("not initialized"));
+        if stored_admin != *admin {
+            panic!("admin only");
+        }
+    }
+
+    fn token(env: &Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Token)
+            .unwrap_or_else(|| panic!("not initialized"))
+    }
+}
+
+impl SubscriptionTier {
+    fn from_u32(value: u32) -> Option<Self> {
+        match value {
+            0 => Some(Self::Free),
+            1 => Some(Self::Pro),
+            2 => Some(Self::Elite),
+            _ => None,
+        }
+    }
+}

--- a/contracts/conditional_reward/src/test.rs
+++ b/contracts/conditional_reward/src/test.rs
@@ -1,0 +1,390 @@
+#![cfg(test)]
+
+use crate::{
+    Condition, ConditionType, ConditionalRewardContract, ConditionalRewardContractClient,
+    PlayerIdentityView, SocialLinksView, SubscriptionTier,
+};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, IntoVal, Map, String, Symbol, Val, Vec,
+};
+
+#[contract]
+struct MockNft;
+
+#[contractimpl]
+impl MockNft {
+    pub fn set_owner(env: Env, token_id: u32, owner: Address) {
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("OWNER"), token_id), &owner);
+    }
+
+    pub fn owner_of(env: Env, token_id: u32) -> Address {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("OWNER"), token_id))
+            .unwrap()
+    }
+}
+
+#[contract]
+struct MockProof;
+
+#[contractimpl]
+impl MockProof {
+    pub fn set_count(env: Env, player: Address, activity_type: u32, count: u32) {
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("CNT"), player, activity_type), &count);
+    }
+
+    pub fn get_activity_count(env: Env, player: Address, activity_type: u32) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("CNT"), player, activity_type))
+            .unwrap_or(0)
+    }
+}
+
+#[contract]
+struct MockIdentity;
+
+#[contractimpl]
+impl MockIdentity {
+    pub fn set_identity(env: Env, player: Address, registered_at: u64) {
+        let identity = PlayerIdentityView {
+            address: player.clone(),
+            username: String::from_str(&env, "player"),
+            avatar_hash: None,
+            bio_hash: None,
+            social_links: SocialLinksView {
+                twitter: None,
+                discord: None,
+                github: None,
+            },
+            registered_at,
+            verified: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("ID"), player), &identity);
+    }
+
+    pub fn resolve_address(env: Env, player: Address) -> Option<PlayerIdentityView> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("ID"), player))
+    }
+}
+
+#[contract]
+struct MockSubscription;
+
+#[contractimpl]
+impl MockSubscription {
+    pub fn set_tier(env: Env, player: Address, tier: SubscriptionTier) {
+        env.storage()
+            .persistent()
+            .set(&(symbol_short!("TIER"), player), &tier);
+    }
+
+    pub fn has_access(env: Env, player: Address, required_tier: SubscriptionTier) -> bool {
+        let tier: SubscriptionTier = env
+            .storage()
+            .persistent()
+            .get(&(symbol_short!("TIER"), player))
+            .unwrap_or(SubscriptionTier::Free);
+        (tier as u32) >= (required_tier as u32)
+    }
+}
+
+struct TestContext {
+    env: Env,
+    admin: Address,
+    player: Address,
+    other_player: Address,
+    contract: ConditionalRewardContractClient<'static>,
+    token: TokenClient<'static>,
+    nft: Address,
+    proof: Address,
+    identity: Address,
+    subscription: Address,
+}
+
+impl TestContext {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(100);
+
+        let admin = Address::generate(&env);
+        let player = Address::generate(&env);
+        let other_player = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        let token = TokenClient::new(&env, &token_id);
+        let asset_admin = StellarAssetClient::new(&env, &token_id);
+
+        let contract_id = env.register_contract(None, ConditionalRewardContract);
+        let contract = ConditionalRewardContractClient::new(&env, &contract_id);
+        contract.initialize(&admin, &token_id);
+
+        let nft = env.register_contract(None, MockNft);
+        let proof = env.register_contract(None, MockProof);
+        let identity = env.register_contract(None, MockIdentity);
+        let subscription = env.register_contract(None, MockSubscription);
+
+        asset_admin.mint(&admin, &10_000);
+
+        Self {
+            env,
+            admin,
+            player,
+            other_player,
+            contract,
+            token,
+            nft,
+            proof,
+            identity,
+            subscription,
+        }
+    }
+}
+
+fn params(env: &Env, entries: &[(Symbol, Val)]) -> Map<Symbol, Val> {
+    let mut map = Map::new(env);
+    for (key, value) in entries.iter() {
+        map.set(key.clone(), value.clone());
+    }
+    map
+}
+
+fn nft_condition(env: &Env, contract: &Address, token_id: u32, or_group: u32) -> Condition {
+    Condition {
+        condition_type: ConditionType::NftHeld,
+        params: params(
+            env,
+            &[
+                (symbol_short!("contract"), contract.clone().into_val(env)),
+                (symbol_short!("token_id"), token_id.into_val(env)),
+            ],
+        ),
+        or_group,
+    }
+}
+
+fn solve_condition(
+    env: &Env,
+    contract: &Address,
+    min: u32,
+    activity_type: u32,
+    or_group: u32,
+) -> Condition {
+    Condition {
+        condition_type: ConditionType::SolveCountGte,
+        params: params(
+            env,
+            &[
+                (symbol_short!("contract"), contract.clone().into_val(env)),
+                (symbol_short!("min"), min.into_val(env)),
+                (symbol_short!("activity"), activity_type.into_val(env)),
+            ],
+        ),
+        or_group,
+    }
+}
+
+fn registration_condition(env: &Env, contract: &Address, days: u64, or_group: u32) -> Condition {
+    Condition {
+        condition_type: ConditionType::RegistrationAgeGte,
+        params: params(
+            env,
+            &[
+                (symbol_short!("contract"), contract.clone().into_val(env)),
+                (symbol_short!("days"), days.into_val(env)),
+            ],
+        ),
+        or_group,
+    }
+}
+
+fn tier_condition(
+    env: &Env,
+    contract: &Address,
+    tier: SubscriptionTier,
+    or_group: u32,
+) -> Condition {
+    Condition {
+        condition_type: ConditionType::TierGte,
+        params: params(
+            env,
+            &[
+                (symbol_short!("contract"), contract.clone().into_val(env)),
+                (symbol_short!("tier"), (tier as u32).into_val(env)),
+            ],
+        ),
+        or_group,
+    }
+}
+
+fn configure_player(ctx: &TestContext) {
+    MockNftClient::new(&ctx.env, &ctx.nft).set_owner(&7u32, &ctx.player);
+    MockProofClient::new(&ctx.env, &ctx.proof).set_count(&ctx.player, &0u32, &60u32);
+    MockIdentityClient::new(&ctx.env, &ctx.identity).set_identity(&ctx.player, &60u64);
+    MockSubscriptionClient::new(&ctx.env, &ctx.subscription)
+        .set_tier(&ctx.player, &SubscriptionTier::Elite);
+}
+
+#[test]
+fn test_eligible_claim() {
+    let ctx = TestContext::new();
+    configure_player(&ctx);
+
+    let conditions = Vec::from_array(
+        &ctx.env,
+        [
+            nft_condition(&ctx.env, &ctx.nft, 7, 0),
+            solve_condition(&ctx.env, &ctx.proof, 50, 0, 0),
+            registration_condition(&ctx.env, &ctx.identity, 30, 0),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Pro, 1),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Elite, 1),
+        ],
+    );
+
+    let reward_id = ctx
+        .contract
+        .create_reward(&ctx.admin, &conditions, &100i128, &2u32);
+    let (eligible, failed) = ctx.contract.check_eligibility(&reward_id, &ctx.player);
+    assert!(eligible);
+    assert!(failed.is_empty());
+
+    let admin_before = ctx.token.balance(&ctx.admin);
+    let player_before = ctx.token.balance(&ctx.player);
+    ctx.contract.claim(&reward_id, &ctx.player);
+
+    assert_eq!(ctx.token.balance(&ctx.player), player_before + 100);
+    assert_eq!(ctx.token.balance(&ctx.admin), admin_before);
+
+    let reward = ctx.contract.get_reward(&reward_id);
+    assert!(reward.active);
+    assert_eq!(reward.claims_remaining, 1);
+}
+
+#[test]
+fn test_partially_failing_conditions_reported() {
+    let ctx = TestContext::new();
+
+    MockNftClient::new(&ctx.env, &ctx.nft).set_owner(&7u32, &ctx.player);
+    MockProofClient::new(&ctx.env, &ctx.proof).set_count(&ctx.player, &0u32, &12u32);
+    MockIdentityClient::new(&ctx.env, &ctx.identity).set_identity(&ctx.player, &80u64);
+    MockSubscriptionClient::new(&ctx.env, &ctx.subscription)
+        .set_tier(&ctx.player, &SubscriptionTier::Free);
+
+    let conditions = Vec::from_array(
+        &ctx.env,
+        [
+            nft_condition(&ctx.env, &ctx.nft, 7, 0),
+            solve_condition(&ctx.env, &ctx.proof, 50, 0, 0),
+            registration_condition(&ctx.env, &ctx.identity, 10, 0),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Pro, 2),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Elite, 2),
+        ],
+    );
+
+    let reward_id = ctx
+        .contract
+        .create_reward(&ctx.admin, &conditions, &100i128, &1u32);
+    let (eligible, failed) = ctx.contract.check_eligibility(&reward_id, &ctx.player);
+
+    assert!(!eligible);
+    assert_eq!(failed.len(), 3);
+    assert_eq!(failed.get(0).unwrap().index, 1);
+    assert_eq!(failed.get(1).unwrap().or_group, 2);
+    assert_eq!(failed.get(2).unwrap().or_group, 2);
+}
+
+#[test]
+#[should_panic(expected = "max claims reached")]
+fn test_max_claims_cap() {
+    let ctx = TestContext::new();
+    configure_player(&ctx);
+    MockProofClient::new(&ctx.env, &ctx.proof).set_count(&ctx.other_player, &0u32, &60u32);
+    MockIdentityClient::new(&ctx.env, &ctx.identity).set_identity(&ctx.other_player, &60u64);
+    MockSubscriptionClient::new(&ctx.env, &ctx.subscription)
+        .set_tier(&ctx.other_player, &SubscriptionTier::Elite);
+
+    let conditions = Vec::from_array(
+        &ctx.env,
+        [
+            solve_condition(&ctx.env, &ctx.proof, 50, 0, 0),
+            registration_condition(&ctx.env, &ctx.identity, 30, 0),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Elite, 0),
+        ],
+    );
+
+    let reward_id = ctx
+        .contract
+        .create_reward(&ctx.admin, &conditions, &100i128, &1u32);
+    ctx.contract.claim(&reward_id, &ctx.player);
+    ctx.contract.claim(&reward_id, &ctx.other_player);
+}
+
+#[test]
+fn test_deactivation_refunds_unclaimed_funds() {
+    let ctx = TestContext::new();
+    configure_player(&ctx);
+
+    let conditions = Vec::from_array(
+        &ctx.env,
+        [
+            nft_condition(&ctx.env, &ctx.nft, 7, 0),
+            solve_condition(&ctx.env, &ctx.proof, 50, 0, 0),
+            registration_condition(&ctx.env, &ctx.identity, 30, 0),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Pro, 0),
+        ],
+    );
+
+    let reward_id = ctx
+        .contract
+        .create_reward(&ctx.admin, &conditions, &100i128, &3u32);
+    ctx.contract.claim(&reward_id, &ctx.player);
+
+    let admin_before = ctx.token.balance(&ctx.admin);
+    let refund = ctx.contract.deactivate_reward(&ctx.admin, &reward_id);
+    assert_eq!(refund, 200);
+    assert_eq!(ctx.token.balance(&ctx.admin), admin_before + 200);
+
+    let reward = ctx.contract.get_reward(&reward_id);
+    assert!(!reward.active);
+    assert_eq!(reward.claims_remaining, 2);
+}
+
+#[test]
+#[should_panic(expected = "player already claimed")]
+fn test_duplicate_claim_rejected() {
+    let ctx = TestContext::new();
+    configure_player(&ctx);
+
+    let conditions = Vec::from_array(
+        &ctx.env,
+        [
+            nft_condition(&ctx.env, &ctx.nft, 7, 0),
+            solve_condition(&ctx.env, &ctx.proof, 50, 0, 0),
+            registration_condition(&ctx.env, &ctx.identity, 30, 0),
+            tier_condition(&ctx.env, &ctx.subscription, SubscriptionTier::Pro, 0),
+        ],
+    );
+
+    let reward_id = ctx
+        .contract
+        .create_reward(&ctx.admin, &conditions, &100i128, &2u32);
+    ctx.contract.claim(&reward_id, &ctx.player);
+    ctx.contract.claim(&reward_id, &ctx.player);
+}


### PR DESCRIPTION
## Summary

- add a new `conditional_reward` Soroban contract for milestone-based token payouts
- support `nft_held`, `solve_count_gte`, `registration_age_gte`, and `tier_gte` conditions with default AND logic and optional OR groups
- add eligibility reporting, single-claim enforcement, deactivation with refund recovery, and focused contract tests

## Validation

- `cargo test -p conditional_reward`

## Notes

- Testnet deployment was not performed from this environment because no deploy credentials or target network configuration were available locally.

Closes #174