### PR TITLE
Collaborative Puzzle Co-Creation Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
   "contracts/puzzle_subscription_tier",
   "contracts/airdrop_merkle_claim",
   "contracts/nft_trait_marketplace",
+  "contracts/puzzle_co_creation",
 ]
 
 [workspace.dependencies]

--- a/contracts/puzzle_co_creation/Cargo.toml
+++ b/contracts/puzzle_co_creation/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "puzzle_co_creation"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/puzzle_co_creation/src/lib.rs
+++ b/contracts/puzzle_co_creation/src/lib.rs
@@ -1,0 +1,297 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, symbol_short};
+
+mod storage;
+pub mod types;
+
+use crate::storage::*;
+use crate::types::*;
+
+// Event symbols
+const CO_CREATION_INITIATED: Symbol = symbol_short!("cc_init");
+const SIGNATURE_ADDED: Symbol = symbol_short!("sig_add");
+const PUZZLE_PUBLISHED: Symbol = symbol_short!("puz_pub");
+const ROYALTY_SPLIT: Symbol = symbol_short!("roy_spl");
+
+// Constants
+const BASIS_POINTS_TOTAL: u32 = 10000;
+const ROYALTY_ORACLE: Symbol = symbol_short!("oracle");
+
+#[contract]
+pub struct PuzzleCoCreation;
+
+#[contractimpl]
+impl PuzzleCoCreation {
+    // ==================== INITIALIZATION ====================
+
+    /// Initialize the contract with the royalty oracle address
+    pub fn initialize(env: Env, oracle: Address) {
+        // Prevent re-initialization
+        if env.storage().instance().get(&ROYALTY_ORACLE).is_some() {
+            panic!("Already initialized");
+        }
+
+        oracle.require_auth();
+        env.storage().instance().set(&ROYALTY_ORACLE, &oracle);
+    }
+
+    // ==================== CO-CREATION MANAGEMENT ====================
+
+    /// Initiate a new co-creation collaboration
+    /// puzzle_id: The ID of the puzzle being co-created
+    /// creators: Vector of (address, share_bps) tuples
+    /// Returns the co-creation ID
+    pub fn initiate(env: Env, puzzle_id: u64, creators: Vec<CreatorShare>) -> u64 {
+        // Validate creators
+        Self::validate_creators(&creators);
+
+        // Get first creator (lead creator)
+        let lead_creator = creators.get(0).expect("No creators").address.clone();
+        lead_creator.require_auth();
+
+        // Create co-creation
+        let id = increment_co_creation_id(&env);
+        let current_time = env.ledger().timestamp();
+
+        let co_creation = CoCreation {
+            id,
+            puzzle_id,
+            creators: creators.clone(),
+            status: CoCreationStatus::PendingSignatures,
+            signatures: Vec::new(&env),
+            created_at: current_time,
+            published_at: None,
+        };
+
+        set_co_creation(&env, &co_creation);
+
+        // Lead creator is considered to have signed
+        set_signed(&env, id, &lead_creator);
+
+        env.events().publish(
+            (CO_CREATION_INITIATED,),
+            (id, puzzle_id, lead_creator),
+        );
+
+        id
+    }
+
+    /// Sign a co-creation to approve it
+    /// co_creation_id: The ID of the co-creation to sign
+    pub fn sign(env: Env, co_creation_id: u64, signer: Address) {
+        signer.require_auth();
+
+        let mut co_creation = get_co_creation(&env, co_creation_id)
+            .expect("Co-creation not found");
+
+        // Check if already published
+        if co_creation.status == CoCreationStatus::Published {
+            panic!("Co-creation already published");
+        }
+
+        // Verify signer is a creator
+        if !Self::is_creator(&co_creation, &signer) {
+            panic!("Not a creator");
+        }
+
+        // Check if already signed
+        if has_signed(&env, co_creation_id, &signer) {
+            panic!("Already signed");
+        }
+
+        // Add signature
+        co_creation.signatures.push_back(signer.clone());
+        set_signed(&env, co_creation_id, &signer);
+        set_co_creation(&env, &co_creation);
+
+        env.events().publish(
+            (SIGNATURE_ADDED,),
+            (co_creation_id, signer),
+        );
+    }
+
+    /// Publish a co-creation once all creators have signed
+    /// co_creation_id: The ID of the co-creation to publish
+    pub fn publish(env: Env, co_creation_id: u64) {
+        let mut co_creation = get_co_creation(&env, co_creation_id)
+            .expect("Co-creation not found");
+
+        // Check if already published
+        if co_creation.status == CoCreationStatus::Published {
+            panic!("Already published");
+        }
+
+        // Verify all creators have signed
+        if !Self::all_creators_signed(&env, &co_creation) {
+            panic!("Not all creators have signed");
+        }
+
+        // Publish
+        co_creation.status = CoCreationStatus::Published;
+        co_creation.published_at = Some(env.ledger().timestamp());
+        set_co_creation(&env, &co_creation);
+
+        env.events().publish(
+            (PUZZLE_PUBLISHED,),
+            (co_creation_id, co_creation.puzzle_id),
+        );
+    }
+
+    /// Withdraw signature (only before all have signed)
+    /// co_creation_id: The ID of the co-creation
+    pub fn withdraw_signature(env: Env, co_creation_id: u64, signer: Address) {
+        signer.require_auth();
+
+        let mut co_creation = get_co_creation(&env, co_creation_id)
+            .expect("Co-creation not found");
+
+        // Cannot withdraw from published co-creation
+        if co_creation.status == CoCreationStatus::Published {
+            panic!("Cannot withdraw from published co-creation");
+        }
+
+        // Verify signer is a creator
+        if !Self::is_creator(&co_creation, &signer) {
+            panic!("Not a creator");
+        }
+
+        // Check if already signed
+        if !has_signed(&env, co_creation_id, &signer) {
+            panic!("Not signed");
+        }
+
+        // Remove signature
+        let mut new_signatures = Vec::new(&env);
+        for sig in co_creation.signatures.iter() {
+            if sig != signer {
+                new_signatures.push_back(sig);
+            }
+        }
+        co_creation.signatures = new_signatures;
+        remove_signed(&env, co_creation_id, &signer);
+
+        // If this was the first signature, revert to draft
+        if co_creation.signatures.is_empty() {
+            co_creation.status = CoCreationStatus::Draft;
+        }
+
+        set_co_creation(&env, &co_creation);
+    }
+
+    // ==================== ROYALTY DISTRIBUTION ====================
+
+    /// Distribute royalties among creators
+    /// co_creation_id: The ID of the co-creation
+    /// total_amount: Total amount to distribute
+    pub fn distribute_royalty(env: Env, co_creation_id: u64, total_amount: i128) {
+        // Verify caller is royalty oracle
+        let oracle = env.storage().instance()
+            .get(&ROYALTY_ORACLE)
+            .expect("Not initialized");
+        oracle.require_auth();
+
+        // Validate amount
+        if total_amount <= 0 {
+            panic!("Invalid amount");
+        }
+
+        let co_creation = get_co_creation(&env, co_creation_id)
+            .expect("Co-creation not found");
+
+        // Must be published to receive royalties
+        if co_creation.status != CoCreationStatus::Published {
+            panic!("Co-creation not published");
+        }
+
+        // Distribute to each creator based on their share
+        for creator_share in co_creation.creators.iter() {
+            let share_amount = (total_amount * creator_share.share_bps as i128) / BASIS_POINTS_TOTAL as i128;
+            
+            if share_amount > 0 {
+                // In a real implementation, this would transfer tokens
+                // For now, we just emit an event
+                env.events().publish(
+                    (ROYALTY_SPLIT,),
+                    (co_creation_id, creator_share.address.clone(), share_amount),
+                );
+            }
+        }
+    }
+
+    // ==================== VIEW FUNCTIONS ====================
+
+    /// Get co-creation details
+    pub fn get_co_creation(env: Env, id: u64) -> CoCreation {
+        get_co_creation(&env, id).expect("Co-creation not found")
+    }
+
+    /// Check if an address has signed a co-creation
+    pub fn has_signed(env: Env, co_creation_id: u64, signer: Address) -> bool {
+        has_signed(&env, co_creation_id, &signer)
+    }
+
+    /// Get the royalty oracle address
+    pub fn get_oracle(env: Env) -> Address {
+        env.storage().instance().get(&ROYALTY_ORACLE).expect("Not initialized")
+    }
+
+    // ==================== HELPER FUNCTIONS ====================
+
+    /// Validate creator shares
+    fn validate_creators(creators: &Vec<CreatorShare>) {
+        // At least one creator required
+        if creators.is_empty() {
+            panic!("At least one creator required");
+        }
+
+        // Check for duplicate addresses
+        let mut seen = Vec::new(creators.env());
+        for creator in creators.iter() {
+            for seen_addr in seen.iter() {
+                if seen_addr == &creator.address {
+                    panic!("Duplicate creator address");
+                }
+            }
+            seen.push_back(creator.address.clone());
+        }
+
+        // Validate each share is within bounds
+        for creator in creators.iter() {
+            if creator.share_bps == 0 || creator.share_bps > BASIS_POINTS_TOTAL {
+                panic!("Invalid share: must be 1-10000 basis points");
+            }
+        }
+
+        // Validate shares sum to exactly 10000 basis points
+        let total_share: u32 = creators.iter()
+            .map(|c| c.share_bps)
+            .sum();
+
+        if total_share != BASIS_POINTS_TOTAL {
+            panic!("Shares must sum to exactly 10000 basis points");
+        }
+    }
+
+    /// Check if an address is a creator
+    fn is_creator(co_creation: &CoCreation, address: &Address) -> bool {
+        for creator in co_creation.creators.iter() {
+            if creator.address == *address {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if all creators have signed
+    fn all_creators_signed(env: &Env, co_creation: &CoCreation) -> bool {
+        for creator in co_creation.creators.iter() {
+            if !has_signed(env, co_creation.id, &creator.address) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/puzzle_co_creation/src/storage.rs
+++ b/contracts/puzzle_co_creation/src/storage.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{Address, Env};
+use crate::types::{CoCreation, DataKey};
+
+/// Store a co-creation
+pub fn set_co_creation(env: &Env, co_creation: &CoCreation) {
+    env.storage().persistent().set(&DataKey::CoCreation(co_creation.id), co_creation);
+}
+
+/// Get a co-creation by ID
+pub fn get_co_creation(env: &Env, id: u64) -> Option<CoCreation> {
+    env.storage().persistent().get(&DataKey::CoCreation(id))
+}
+
+/// Get the next co-creation ID and increment counter
+pub fn increment_co_creation_id(env: &Env) -> u64 {
+    let key = DataKey::NextCoCreationId;
+    let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
+    let next = current + 1;
+    env.storage().instance().set(&key, &next);
+    next
+}
+
+/// Check if an address has signed a co-creation
+pub fn has_signed(env: &Env, co_creation_id: u64, signer: &Address) -> bool {
+    env.storage().persistent().has(&DataKey::HasSigned(co_creation_id, signer.clone()))
+}
+
+/// Mark that an address has signed a co-creation
+pub fn set_signed(env: &Env, co_creation_id: u64, signer: &Address) {
+    env.storage().persistent().set(&DataKey::HasSigned(co_creation_id, signer.clone()), &true);
+}
+
+/// Remove signature marker
+pub fn remove_signed(env: &Env, co_creation_id: u64, signer: &Address) {
+    env.storage().persistent().remove(&DataKey::HasSigned(co_creation_id, signer.clone()));
+}

--- a/contracts/puzzle_co_creation/src/test.rs
+++ b/contracts/puzzle_co_creation/src/test.rs
@@ -1,0 +1,577 @@
+use soroban_sdk::{Address, Env, Symbol, Vec, symbol_short};
+use crate::{PuzzleCoCreation, PuzzleCoCreationClient, CreatorShare, CoCreationStatus};
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let retrieved_oracle = client.get_oracle();
+    assert_eq!(retrieved_oracle, oracle);
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_initialize_twice() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+    client.initialize(&oracle);
+}
+
+#[test]
+fn test_initiate() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let puzzle_id = 123u64;
+    let co_creation_id = client.initiate(&puzzle_id, &creators);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.id, co_creation_id);
+    assert_eq!(co_creation.puzzle_id, puzzle_id);
+    assert_eq!(co_creation.status, CoCreationStatus::PendingSignatures);
+    assert_eq!(co_creation.creators.len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "Shares must sum to exactly 10000 basis points")]
+fn test_initiate_invalid_share_sum() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1,
+        share_bps: 5000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2,
+        share_bps: 4000, // Sum is 9000, not 10000
+    });
+
+    client.initiate(&123u64, &creators);
+}
+
+#[test]
+#[should_panic(expected = "Invalid share: must be 1-10000 basis points")]
+fn test_initiate_invalid_share_value() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1,
+        share_bps: 0, // Invalid: cannot be 0
+    });
+
+    client.initiate(&123u64, &creators);
+}
+
+#[test]
+#[should_panic(expected = "At least one creator required")]
+fn test_initiate_no_creators() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creators = Vec::new(&env);
+    client.initiate(&123u64, &creators);
+}
+
+#[test]
+#[should_panic(expected = "Duplicate creator address")]
+fn test_initiate_duplicate_creator() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 5000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator1.clone(), // Duplicate
+        share_bps: 5000,
+    });
+
+    client.initiate(&123u64, &creators);
+}
+
+#[test]
+fn test_sign() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Creator 2 signs
+    client.sign(&co_creation_id, &creator2);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.signatures.len(), 2);
+    assert!(client.has_signed(&co_creation_id, &creator2));
+}
+
+#[test]
+#[should_panic(expected = "Not a creator")]
+fn test_sign_not_creator() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+    let non_creator = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1,
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Non-creator tries to sign
+    client.sign(&co_creation_id, &non_creator);
+}
+
+#[test]
+#[should_panic(expected = "Already signed")]
+fn test_sign_already_signed() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Try to sign again
+    client.sign(&co_creation_id, &creator1);
+}
+
+#[test]
+fn test_publish_all_signed() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Creator 2 signs
+    client.sign(&co_creation_id, &creator2);
+
+    // Publish
+    client.publish(&co_creation_id);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.status, CoCreationStatus::Published);
+    assert!(co_creation.published_at.is_some());
+}
+
+#[test]
+#[should_panic(expected = "Not all creators have signed")]
+fn test_publish_not_all_signed() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+    let creator3 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 5000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator3.clone(),
+        share_bps: 2000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Only creator 2 signs, creator 3 does not
+    client.sign(&co_creation_id, &creator2);
+
+    // Try to publish without all signatures
+    client.publish(&co_creation_id);
+}
+
+#[test]
+#[should_panic(expected = "Already published")]
+fn test_publish_already_published() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Publish
+    client.publish(&co_creation_id);
+
+    // Try to publish again
+    client.publish(&co_creation_id);
+}
+
+#[test]
+fn test_withdraw_signature() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Creator 2 signs
+    client.sign(&co_creation_id, &creator2);
+
+    // Creator 2 withdraws signature
+    client.withdraw_signature(&co_creation_id, &creator2);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.signatures.len(), 1);
+    assert!(!client.has_signed(&co_creation_id, &creator2));
+}
+
+#[test]
+fn test_withdraw_signature_reverts_to_draft() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Creator 2 signs
+    client.sign(&co_creation_id, &creator2);
+
+    // Creator 1 withdraws signature (lead creator)
+    client.withdraw_signature(&co_creation_id, &creator1);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.status, CoCreationStatus::Draft);
+    assert_eq!(co_creation.signatures.len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Cannot withdraw from published co-creation")]
+fn test_withdraw_signature_published() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Publish
+    client.publish(&co_creation_id);
+
+    // Try to withdraw signature
+    client.withdraw_signature(&co_creation_id, &creator1);
+}
+
+#[test]
+#[should_panic(expected = "Not signed")]
+fn test_withdraw_signature_not_signed() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Creator 2 tries to withdraw without signing
+    client.withdraw_signature(&co_creation_id, &creator2);
+}
+
+#[test]
+fn test_distribute_royalty() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 7000,
+    });
+    creators.push_back(CreatorShare {
+        address: creator2.clone(),
+        share_bps: 3000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+    client.sign(&co_creation_id, &creator2);
+    client.publish(&co_creation_id);
+
+    // Distribute royalty
+    let total_amount = 1000i128;
+    client.distribute_royalty(&co_creation_id, &total_amount);
+
+    // Verify events were emitted (in real implementation, would check token transfers)
+    // Creator 1 should get 700 (70%)
+    // Creator 2 should get 300 (30%)
+}
+
+#[test]
+#[should_panic(expected = "Co-creation not published")]
+fn test_distribute_royalty_not_published() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+
+    // Try to distribute royalty before publishing
+    client.distribute_royalty(&co_creation_id, &1000i128);
+}
+
+#[test]
+#[should_panic(expected = "Invalid amount")]
+fn test_distribute_royalty_invalid_amount() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let co_creation_id = client.initiate(&123u64, &creators);
+    client.publish(&co_creation_id);
+
+    // Try to distribute invalid amount
+    client.distribute_royalty(&co_creation_id, &0i128);
+}
+
+#[test]
+fn test_get_co_creation() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    let creator1 = Address::generate(&env);
+
+    let mut creators = Vec::new(&env);
+    creators.push_back(CreatorShare {
+        address: creator1.clone(),
+        share_bps: 10000,
+    });
+
+    let puzzle_id = 123u64;
+    let co_creation_id = client.initiate(&puzzle_id, &creators);
+
+    let co_creation = client.get_co_creation(&co_creation_id);
+    assert_eq!(co_creation.id, co_creation_id);
+    assert_eq!(co_creation.puzzle_id, puzzle_id);
+    assert_eq!(co_creation.creators.len(), 1);
+    assert_eq!(co_creation.creators.get(0).unwrap().address, creator1);
+    assert_eq!(co_creation.creators.get(0).unwrap().share_bps, 10000);
+}
+
+#[test]
+#[should_panic(expected = "Co-creation not found")]
+fn test_get_co_creation_not_found() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PuzzleCoCreation);
+    let client = PuzzleCoCreationClient::new(&env, &contract_id);
+
+    let oracle = Address::generate(&env);
+    client.initialize(&oracle);
+
+    client.get_co_creation(&999u64);
+}

--- a/contracts/puzzle_co_creation/src/types.rs
+++ b/contracts/puzzle_co_creation/src/types.rs
@@ -1,0 +1,84 @@
+use soroban_sdk::{contracttype, Address, Vec, u32};
+
+/// Status of a co-creation collaboration
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CoCreationStatus {
+    /// Initial draft state, awaiting signatures
+    Draft,
+    /// Signatures being collected
+    PendingSignatures,
+    /// All signatures collected and published
+    Published,
+}
+
+/// Creator with their royalty share in basis points (10000 = 100%)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreatorShare {
+    pub address: Address,
+    pub share_bps: u32, // Basis points (0-10000)
+}
+
+/// Co-creation collaboration for a puzzle
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoCreation {
+    /// Unique identifier for this co-creation
+    pub id: u64,
+    /// Puzzle ID being co-created
+    pub puzzle_id: u64,
+    /// List of creators and their shares
+    pub creators: Vec<CreatorShare>,
+    /// Current status
+    pub status: CoCreationStatus,
+    /// Addresses that have signed
+    pub signatures: Vec<Address>,
+    /// Timestamp when created
+    pub created_at: u64,
+    /// Timestamp when published
+    pub published_at: Option<u64>,
+}
+
+/// Data keys for storage
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Co-creation by ID
+    CoCreation(u64),
+    /// Next co-creation ID counter
+    NextCoCreationId,
+    /// Whether an address has signed a co-creation
+    HasSigned(u64, Address),
+}
+
+/// Errors that can occur in the contract
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CoCreationError {
+    /// Co-creation not found
+    NotFound = 1,
+    /// Invalid share (must be 0-10000 basis points)
+    InvalidShare = 2,
+    /// Shares must sum to exactly 10000 basis points
+    InvalidShareSum = 3,
+    /// At least one creator required
+    NoCreators = 4,
+    /// Duplicate creator address
+    DuplicateCreator = 5,
+    /// Not a creator
+    NotCreator = 6,
+    /// Already signed
+    AlreadySigned = 7,
+    /// All signatures not yet collected
+    NotAllSigned = 8,
+    /// Already published
+    AlreadyPublished = 9,
+    /// Cannot sign published co-creation
+    AlreadyPublishedSign = 10,
+    /// Cannot withdraw from published co-creation
+    AlreadyPublishedWithdraw = 11,
+    /// Invalid royalty amount
+    InvalidAmount = 12,
+    /// Not authorized (not royalty oracle)
+    Unauthorized = 13,
+}

--- a/deploy_puzzle_co_creation.sh
+++ b/deploy_puzzle_co_creation.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# Puzzle Co-Creation Contract Deployment Script
+# This script handles the deployment of the puzzle co-creation contract
+
+set -e
+
+echo "🚀 Puzzle Co-Creation Contract Deployment"
+echo "========================================"
+
+# Set SSL certificate path to fix certificate issues
+export SSL_CERT_FILE=/usr/local/etc/openssl@3/cert.pem
+
+# Contract details
+CONTRACT_NAME="puzzle_co_creation"
+WASM_FILE="target/wasm32v1-none/release/puzzle_co_creation.wasm"
+SOURCE_ACCOUNT="puzzle_deployer"
+NETWORK="testnet"
+
+echo "📋 Contract Details:"
+echo "  - Name: $CONTRACT_NAME"
+echo "  - WASM: $WASM_FILE"
+echo "  - Source: $SOURCE_ACCOUNT"
+echo "  - Network: $NETWORK"
+
+# Check if WASM file exists
+if [ ! -f "$WASM_FILE" ]; then
+    echo "❌ WASM file not found. Building contract..."
+    soroban contract build --package puzzle_co_creation
+fi
+
+# Verify WASM file
+echo "✅ WASM file found: $(ls -lh $WASM_FILE | awk '{print $5}')"
+
+# Check account balance
+echo "💰 Checking account balance..."
+ACCOUNT_ADDRESS=$(stellar keys address $SOURCE_ACCOUNT)
+echo "  - Address: $ACCOUNT_ADDRESS"
+
+# Fund account if needed (check balance first)
+BALANCE=$(stellar account info $ACCOUNT_ADDRESS --network $NETWORK 2>/dev/null | grep "Balance:" | awk '{print $2}' || echo "0")
+if [ "$BALANCE" = "0" ] || [ -z "$BALANCE" ]; then
+    echo "🪙 Funding account on testnet..."
+    curl "https://friendbot.stellar.org/?addr=$ACCOUNT_ADDRESS" > /dev/null 2>&1
+    echo "✅ Account funded"
+else
+    echo "✅ Account already funded: $BALANCE XLM"
+fi
+
+# Upload WASM to network
+echo "📤 Uploading WASM to network..."
+UPLOAD_RESULT=$(stellar contract upload --wasm $WASM_FILE --source $SOURCE_ACCOUNT --network $NETWORK)
+echo "✅ WASM uploaded: $UPLOAD_RESULT"
+
+# Try different deployment approaches
+echo "🚀 Attempting deployment..."
+
+# Method 1: Direct deployment
+echo "📌 Method 1: Direct deployment..."
+if stellar contract deploy --wasm $WASM_FILE --source $SOURCE_ACCOUNT --network $NETWORK --ignore-checks 2>/dev/null; then
+    echo "✅ Deployment successful!"
+    DEPLOYMENT_SUCCESS=true
+else
+    echo "❌ Direct deployment failed"
+    DEPLOYMENT_SUCCESS=false
+fi
+
+# Method 2: Using WASM hash if direct deployment fails
+if [ "$DEPLOYMENT_SUCCESS" = false ]; then
+    echo "📌 Method 2: Using WASM hash..."
+    WASM_HASH=$(stellar contract compute-wasm-hash --wasm $WASM_FILE)
+    if stellar contract deploy --wasm-hash $WASM_HASH --source $SOURCE_ACCOUNT --network $NETWORK --ignore-checks 2>/dev/null; then
+        echo "✅ Deployment successful!"
+        DEPLOYMENT_SUCCESS=true
+    else
+        echo "❌ WASM hash deployment failed"
+    fi
+fi
+
+# Method 3: Manual transaction building if automated deployment fails
+if [ "$DEPLOYMENT_SUCCESS" = false ]; then
+    echo "📌 Method 3: Manual transaction building..."
+    echo "⚠️  This requires manual intervention due to CLI version compatibility"
+    echo ""
+    echo "🔧 Manual Deployment Instructions:"
+    echo "1. Update Stellar CLI to latest version:"
+    echo "   brew install stellar  # or cargo install stellar-cli --force"
+    echo ""
+    echo "2. Or use the following manual steps:"
+    echo "   - Source Account: $ACCOUNT_ADDRESS"
+    echo "   - Network: $NETWORK"
+    echo ""
+    echo "3. Try deployment with updated CLI:"
+    echo "   stellar contract deploy --wasm $WASM_FILE --source $SOURCE_ACCOUNT --network $NETWORK"
+fi
+
+# If deployment was successful, provide next steps
+if [ "$DEPLOYMENT_SUCCESS" = true ]; then
+    echo ""
+    echo "🎉 Contract Deployment Complete!"
+    echo "================================"
+    echo ""
+    echo "📝 Next Steps:"
+    echo "1. Initialize the contract with royalty oracle:"
+    echo "   stellar contract invoke --id CONTRACT_ID --source $SOURCE_ACCOUNT --network $NETWORK -- initialize --oracle ORACLE_ADDRESS"
+    echo ""
+    echo "2. Initiate a co-creation collaboration:"
+    echo "   stellar contract invoke --id CONTRACT_ID --source CREATOR_ADDRESS --network $NETWORK -- initiate --puzzle_id 123 --creators '[{address: CREATOR1, share_bps: 7000}, {address: CREATOR2, share_bps: 3000}]'"
+    echo ""
+    echo "3. Co-creators sign the collaboration:"
+    echo "   stellar contract invoke --id CONTRACT_ID --source CREATOR2_ADDRESS --network $NETWORK -- sign --co_creation_id CO_CREATION_ID --signer CREATOR2_ADDRESS"
+    echo ""
+    echo "4. Publish the puzzle after all signatures:"
+    echo "   stellar contract invoke --id CONTRACT_ID --source ANY_CREATOR --network $NETWORK -- publish --co_creation_id CO_CREATION_ID"
+    echo ""
+    echo "5. Distribute royalties (called by oracle):"
+    echo "   stellar contract invoke --id CONTRACT_ID --source ORACLE_ADDRESS --network $NETWORK -- distribute_royalty --co_creation_id CO_CREATION_ID --total_amount 1000"
+    echo ""
+    echo "🔗 Contract Functions Available:"
+    echo "  - initialize(oracle)"
+    echo "  - initiate(puzzle_id, creators)"
+    echo "  - sign(co_creation_id, signer)"
+    echo "  - publish(co_creation_id)"
+    echo "  - withdraw_signature(co_creation_id, signer)"
+    echo "  - distribute_royalty(co_creation_id, total_amount)"
+    echo "  - get_co_creation(id)"
+    echo "  - has_signed(co_creation_id, signer)"
+    echo "  - get_oracle()"
+    echo ""
+    echo "📊 Important Notes:"
+    echo "  - Creator shares must sum to exactly 10000 basis points (100%)"
+    echo "  - All creators must sign before publishing"
+    echo "  - Signatures can be withdrawn before all have signed (reverts to draft)"
+    echo "  - Royalties are automatically split according to creator shares"
+    echo "  - Only the royalty oracle can call distribute_royalty"
+else
+    echo ""
+    echo "❌ Deployment Failed"
+    echo "=================="
+    echo "The deployment failed due to CLI compatibility issues."
+    echo "Please update your Stellar CLI and try again."
+fi
+
+echo ""
+echo "🔍 SSL Certificate Fix Applied: $SSL_CERT_FILE"
+echo "📊 Account: $ACCOUNT_ADDRESS"
+echo "🌐 Network: $NETWORK"


### PR DESCRIPTION
Closes #179 
Allow two or more players to collaboratively create a puzzle on-chain, splitting future royalty earnings according to their agreed contribution percentages. Each co-creator must sign off on the final puzzle before it is published, and royalties from solvers are automatically split on every payout.