### PR TITLE
feat(achievement_nft): optimize gas usage by consolidating counters a…

### DIFF
--- a/contracts/achievement_nft/src/lib.rs
+++ b/contracts/achievement_nft/src/lib.rs
@@ -14,11 +14,24 @@ pub struct Achievement {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Counters {
+    pub next_token_id: u32,
+    pub total_supply: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollectionItem {
+    pub token_id: u32,
+    pub puzzle_id: u32,
+}
+
+#[contracttype]
 pub enum DataKey {
     Achievement(u32),
     OwnerCollection(Address),
-    NextTokenId,
-    TotalSupply,
+    Counters,
     Admin,
     PuzzleCompleted(Address, u32),
 }
@@ -35,8 +48,13 @@ impl AchievementNFT {
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::NextTokenId, &1u32);
-        env.storage().instance().set(&DataKey::TotalSupply, &0u32);
+        env.storage().instance().set(
+            &DataKey::Counters,
+            &Counters {
+                next_token_id: 1,
+                total_supply: 0,
+            },
+        );
     }
 
     //  Mark puzzle completed (admin only)
@@ -44,7 +62,7 @@ impl AchievementNFT {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
-        let key = DataKey::PuzzleCompleted(user.clone(), puzzle_id);
+        let key = DataKey::PuzzleCompleted(user, puzzle_id);
 
         env.storage().persistent().set(&key, &true);
         env.storage().persistent().extend_ttl(&key, 100_000, 500_000);
@@ -74,7 +92,13 @@ impl AchievementNFT {
 
     // 🔹 Internal mint logic
     fn mint_internal(env: Env, to: Address, puzzle_id: u32, metadata: String) -> u32 {
-        let token_id: u32 = env.storage().instance().get(&DataKey::NextTokenId).unwrap();
+        let mut counters: Counters = env
+            .storage()
+            .instance()
+            .get(&DataKey::Counters)
+            .expect("Not initialized");
+
+        let token_id = counters.next_token_id;
 
         let achievement = Achievement {
             owner: to.clone(),
@@ -89,22 +113,25 @@ impl AchievementNFT {
         env.storage().persistent().extend_ttl(&key, 100_000, 500_000);
 
         // Update owner collection
-        let mut collection = Self::get_collection(env.clone(), to.clone());
-        collection.push_back(token_id);
+        let mut collection = Self::get_collection_internal(&env, to.clone());
+        collection.push_back(CollectionItem {
+            token_id,
+            puzzle_id,
+        });
 
         let collection_key = DataKey::OwnerCollection(to.clone());
         env.storage().persistent().set(&collection_key, &collection);
-        env.storage().persistent().extend_ttl(&collection_key, 100_000, 500_000);
+        env.storage()
+            .persistent()
+            .extend_ttl(&collection_key, 100_000, 500_000);
 
         // Update counters
-        env.storage().instance().set(&DataKey::NextTokenId, &(token_id + 1));
-
-        let total: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalSupply, &(total + 1));
+        counters.next_token_id += 1;
+        counters.total_supply += 1;
+        env.storage().instance().set(&DataKey::Counters, &counters);
 
         // Emit event
-        env.events()
-            .publish((symbol_short!("minted"), to.clone()), token_id);
+        env.events().publish((symbol_short!("minted"), to), token_id);
 
         token_id
     }
@@ -128,34 +155,67 @@ impl AchievementNFT {
         }
 
         // Remove from sender
-        let mut from_col = Self::get_collection(env.clone(), from.clone());
-        let index = from_col.first_index_of(token_id).expect("ID not in collection");
-        from_col.remove(index);
+        let mut from_col = Self::get_collection_internal(&env, from.clone());
+        let mut index = None;
+        for (i, item) in from_col.iter().enumerate() {
+            if item.token_id == token_id {
+                index = Some(i as u32);
+                break;
+            }
+        }
 
-        env.storage().persistent().set(&DataKey::OwnerCollection(from.clone()), &from_col);
-        env.storage().persistent().extend_ttl(&DataKey::OwnerCollection(from.clone()), 100_000, 500_000);
+        let idx = index.expect("ID not in collection");
+        from_col.remove(idx);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnerCollection(from.clone()), &from_col);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::OwnerCollection(from), 100_000, 500_000);
 
         // Add to receiver
-        let mut to_col = Self::get_collection(env.clone(), to.clone());
-        to_col.push_back(token_id);
+        let mut to_col = Self::get_collection_internal(&env, to.clone());
+        to_col.push_back(CollectionItem {
+            token_id,
+            puzzle_id: achievement.puzzle_id,
+        });
 
-        env.storage().persistent().set(&DataKey::OwnerCollection(to.clone()), &to_col);
-        env.storage().persistent().extend_ttl(&DataKey::OwnerCollection(to.clone()), 100_000, 500_000);
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnerCollection(to.clone()), &to_col);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::OwnerCollection(to), 100_000, 500_000);
 
         // Update owner
         achievement.owner = to.clone();
-        env.storage().persistent().set(&DataKey::Achievement(token_id), &achievement);
-        env.storage().persistent().extend_ttl(&DataKey::Achievement(token_id), 100_000, 500_000);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Achievement(token_id), &achievement);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Achievement(token_id), 100_000, 500_000);
 
-        env.events().publish((symbol_short!("transfer"), from, to), token_id);
+        env.events()
+            .publish((symbol_short!("transfer"), from, to), token_id);
     }
 
     // 🔹 Get collection
     pub fn get_collection(env: Env, owner: Address) -> Vec<u32> {
+        let collection = Self::get_collection_internal(&env, owner);
+        let mut result = Vec::new(&env);
+        for item in collection.iter() {
+            result.push_back(item.token_id);
+        }
+        result
+    }
+
+    fn get_collection_internal(env: &Env, owner: Address) -> Vec<CollectionItem> {
         env.storage()
             .persistent()
             .get(&DataKey::OwnerCollection(owner))
-            .unwrap_or(Vec::new(&env))
+            .unwrap_or(Vec::new(env))
     }
 
     //  Owner of token
@@ -171,7 +231,15 @@ impl AchievementNFT {
 
     //Total supply
     pub fn total_supply(env: Env) -> u32 {
-        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+        let counters: Counters = env
+            .storage()
+            .instance()
+            .get(&DataKey::Counters)
+            .unwrap_or(Counters {
+                next_token_id: 1,
+                total_supply: 0,
+            });
+        counters.total_supply
     }
 
     // Burn NFT
@@ -182,10 +250,18 @@ impl AchievementNFT {
             .get(&DataKey::Achievement(token_id))
             .expect("Token does not exist");
 
-        let mut collection = Self::get_collection(env.clone(), achievement.owner.clone());
+        let mut collection = Self::get_collection_internal(&env, achievement.owner.clone());
 
-        if let Some(index) = collection.first_index_of(token_id) {
-            collection.remove(index);
+        let mut index = None;
+        for (i, item) in collection.iter().enumerate() {
+            if item.token_id == token_id {
+                index = Some(i as u32);
+                break;
+            }
+        }
+
+        if let Some(idx) = index {
+            collection.remove(idx);
 
             env.storage().persistent().set(
                 &DataKey::OwnerCollection(achievement.owner.clone()),
@@ -193,12 +269,21 @@ impl AchievementNFT {
             );
         }
 
-        env.storage().persistent().remove(&DataKey::Achievement(token_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Achievement(token_id));
 
-        let total: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap();
-        env.storage().instance().set(&DataKey::TotalSupply, &(total - 1));
+        let mut counters: Counters = env
+            .storage()
+            .instance()
+            .get(&DataKey::Counters)
+            .expect("Not initialized");
 
-        env.events().publish((symbol_short!("burn"), achievement.owner), token_id);
+        counters.total_supply -= 1;
+        env.storage().instance().set(&DataKey::Counters, &counters);
+
+        env.events()
+            .publish((symbol_short!("burn"), achievement.owner), token_id);
     }
 
     //  Get full NFT data
@@ -208,16 +293,12 @@ impl AchievementNFT {
 
     //  Get unique puzzle IDs
     pub fn puzzle_ids_of(env: Env, owner: Address) -> Vec<u32> {
-        let token_ids = Self::get_collection(env.clone(), owner);
+        let collection = Self::get_collection_internal(&env, owner);
         let mut puzzles = Vec::new(&env);
 
-        for tid in token_ids.iter() {
-            let token_id = tid.clone();
-
-            if let Some(a) = Self::get_achievement(env.clone(), token_id) {
-                if !puzzles.contains(&a.puzzle_id) {
-                    puzzles.push_back(a.puzzle_id);
-                }
+        for item in collection.iter() {
+            if !puzzles.contains(&item.puzzle_id) {
+                puzzles.push_back(item.puzzle_id);
             }
         }
 
@@ -226,8 +307,13 @@ impl AchievementNFT {
 
     // 🔹 Check puzzle ownership
     pub fn has_puzzle(env: Env, owner: Address, puzzle_id: u32) -> bool {
-        let puzzles = Self::puzzle_ids_of(env, owner);
-        puzzles.contains(&puzzle_id)
+        let collection = Self::get_collection_internal(&env, owner);
+        for item in collection.iter() {
+            if item.puzzle_id == puzzle_id {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/contracts/achievement_nft/src/test.rs
+++ b/contracts/achievement_nft/src/test.rs
@@ -45,6 +45,12 @@ fn test_nft_lifecycle() {
     assert_eq!(user_b_collection.len(), 1);
     assert_eq!(user_b_collection.get(0).unwrap(), token_id);
 
+    // Check puzzle IDs
+    let user_b_puzzles = client.puzzle_ids_of(&user_b);
+    assert_eq!(user_b_puzzles.len(), 1);
+    assert_eq!(user_b_puzzles.get(0).unwrap(), puzzle_id);
+    assert!(client.has_puzzle(&user_b, &puzzle_id));
+
     // Burn from current owner (user_b)
     client.burn(&token_id);
 


### PR DESCRIPTION
# Summary of Changes

## 1. Consolidated Instance Storage Counters
* **Before:** `NextTokenId` and `TotalSupply` were stored as separate ledger entries in instance storage. Each mint or burn operation required multiple get and set host calls.
* **After:** Both counters are now grouped into a single `Counters` struct. This reduces the number of host calls per operation, as the entire state is read/written in one go.

## 2. Optimized Collection Storage (`OwnerCollection`)
* **Before:** `OwnerCollection` stored a `Vec<u32>` of token IDs. Functions like `puzzle_ids_of` had to perform a persistent storage read for every achievement owned by the user to retrieve the `puzzle_id`, leading to $O(N)$ persistent reads.
* **After:** `OwnerCollection` now stores `CollectionItem` structs containing both `token_id` and `puzzle_id`. This allows functions like `puzzle_ids_of` and `has_puzzle` to operate with just one persistent read of the collection entry, regardless of the number of NFTs owned.

## 3. Improved Validation Flow
* Optimized the `mint_internal` logic to read global state counters only once at the beginning of the transaction.
* Reduced redundant clones and host calls across transfer, mint, and burn operations.

---

## Theoretical Gas Usage Comparison

| Operation | Old Storage Reads (Persistent) | New Storage Reads (Persistent) | Savings |
| :--- | :--- | :--- | :--- |
| **mint** | 2 (PuzzleCompleted, Collection) | 2 (PuzzleCompleted, Collection) | 1 Instance Read/Write |
| **puzzle_ids_of** | $1 + N$ ($N$ = owned NFTs) | 1 | $N$ Persistent Reads |
| **has_puzzle** | $1 + N$ | 1 | $N$ Persistent Reads |
| **transfer** | 3 (Achievement, FromCol, ToCol) | 3 (Achievement, FromCol, ToCol) | Internal efficiency |
| **burn** | 2 (Achievement, Collection) | 2 (Achievement, Collection) | 1 Instance Read/Write |

---

## Verification Performed
* Updated `contracts/achievement_nft/src/lib.rs` with optimized logic.
* Updated `contracts/achievement_nft/src/test.rs` to include a verification test for `puzzle_ids_of` and `has_puzzle`.
* Ensured that the public API (specifically `get_collection`) remains compatible with existing callers by mapping the internal optimized storage back to the expected `Vec<u32>`.

The changes have been pushed to the feature branch: `feature/issue-208-optimize-gas-achievement-nft`.

**Closes #208**
"""