### PR TITLE
feat(contracts): implement quest expiry, referral cap, and guild approval flow

### DIFF
--- a/contracts/guild/src/lib.rs
+++ b/contracts/guild/src/lib.rs
@@ -36,6 +36,9 @@ pub enum DataKey {
     Proposal(u32),             // Proposal
     ProposalCounter,           // u32
     Competition(u32),          // Competition
+    WithdrawalProposal(u32),   // WithdrawalProposal
+    WithdrawalProposalCounter, // u32
+    WithdrawalVoted(u32, Address), // bool
 }
 
 //
@@ -49,12 +52,25 @@ pub enum DataKey {
 pub struct GuildConfig {
     pub name: String,
     pub disbanded: bool,
+    pub withdrawal_threshold: i128,
 }
 
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Proposal {
     pub id: u32,
+    pub yes: u32,
+    pub no: u32,
+    pub deadline: u64,
+    pub executed: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WithdrawalProposal {
+    pub id: u32,
+    pub officer: Address,
+    pub amount: i128,
     pub yes: u32,
     pub no: u32,
     pub deadline: u64,
@@ -92,7 +108,7 @@ impl GuildContract {
 
         env.storage().persistent().set(
             &DataKey::Config,
-            &GuildConfig { name, disbanded: false },
+            &GuildConfig { name, disbanded: false, withdrawal_threshold: 10_000 },
         );
 
         env.storage().instance().set(&DataKey::TreasuryToken, &token_address);
@@ -133,10 +149,26 @@ impl GuildContract {
         client.transfer(&member, &env.current_contract_address(), &amount);
     }
 
-    pub fn withdraw(env: Env, officer: Address, amount: i128) {
+    pub fn withdraw(env: Env, officer: Address, amount: i128, deadline: Option<u64>) -> Option<u32> {
         officer.require_auth();
         Self::assert_officer_or_leader(&env, &officer);
         Self::assert_active(&env);
+
+        let config: GuildConfig = env.storage().persistent().get(&DataKey::Config).unwrap();
+        
+        if amount > config.withdrawal_threshold {
+            let mut id: u32 = env.storage().persistent().get(&DataKey::WithdrawalProposalCounter).unwrap_or(0);
+            id += 1;
+            let d = deadline.unwrap_or(env.ledger().timestamp() + 86400); // 24h default
+            
+            let wp = WithdrawalProposal {
+                id, officer, amount, yes: 0, no: 0, deadline: d, executed: false
+            };
+            
+            env.storage().persistent().set(&DataKey::WithdrawalProposal(id), &wp);
+            env.storage().persistent().set(&DataKey::WithdrawalProposalCounter, &id);
+            return Some(id);
+        }
 
         let token_addr: Address =
             env.storage().instance().get(&DataKey::TreasuryToken).unwrap();
@@ -148,6 +180,75 @@ impl GuildContract {
         }
 
         client.transfer(&env.current_contract_address(), &officer, &amount);
+        None
+    }
+
+    pub fn vote_withdrawal(env: Env, member: Address, proposal_id: u32, approve: bool) {
+        member.require_auth();
+        Self::assert_active(&env);
+
+        if Self::get_role(env.clone(), member.clone()).is_none() {
+            panic!("Not a member");
+        }
+
+        let voted_key = DataKey::WithdrawalVoted(proposal_id, member.clone());
+        if env.storage().persistent().has(&voted_key) {
+            panic!("Already voted");
+        }
+
+        let mut proposal: WithdrawalProposal = env.storage().persistent().get(&DataKey::WithdrawalProposal(proposal_id)).unwrap();
+
+        if env.ledger().timestamp() > proposal.deadline {
+            panic!("Voting closed");
+        }
+
+        if proposal.executed {
+            panic!("Already executed");
+        }
+
+        if approve {
+            proposal.yes += 1;
+        } else {
+            proposal.no += 1;
+        }
+
+        env.storage().persistent().set(&DataKey::WithdrawalProposal(proposal_id), &proposal);
+        env.storage().persistent().set(&voted_key, &true);
+    }
+
+    pub fn execute_withdrawal(env: Env, executor: Address, proposal_id: u32) {
+        executor.require_auth();
+        Self::assert_active(&env);
+
+        let mut proposal: WithdrawalProposal = env.storage().persistent().get(&DataKey::WithdrawalProposal(proposal_id)).unwrap();
+
+        if env.ledger().timestamp() > proposal.deadline {
+            panic!("Proposal expired");
+        }
+
+        if proposal.executed {
+            panic!("Already executed");
+        }
+
+        let members: Vec<Address> = env.storage().persistent().get(&DataKey::MembersList).unwrap();
+        let total_members = members.len() as u32;
+
+        if proposal.yes <= total_members / 2 {
+            panic!("Not enough approvals");
+        }
+
+        proposal.executed = true;
+        env.storage().persistent().set(&DataKey::WithdrawalProposal(proposal_id), &proposal);
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::TreasuryToken).unwrap();
+        let client = token::Client::new(&env, &token_addr);
+
+        let balance = client.balance(&env.current_contract_address());
+        if balance < proposal.amount {
+            panic!("Insufficient funds");
+        }
+
+        client.transfer(&env.current_contract_address(), &proposal.officer, &proposal.amount);
     }
 
     // ───────────── SHARED RESOURCES ─────────────

--- a/contracts/quest_chain/src/lib.rs
+++ b/contracts/quest_chain/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Quest {
     pub checkpoint: bool,        // Whether this quest saves progress
     pub branches: Vec<u32>, // Alternative quest IDs (for branching paths)
     pub checkpoint: bool, // Whether this quest saves progress
-    pub expires_at: Option<u64>, // Optional expiry timestamp; None = no deadline
+    pub expiry_timestamp: Option<u64>, // Optional expiry timestamp; None = no deadline
 }
 
 #[contracttype]
@@ -360,12 +360,12 @@ impl QuestChainContract {
         let quest = quest.unwrap();
 
         // Enforce quest expiry deadline
-        if let Some(expires_at) = quest.expires_at {
+        if let Some(expiry_timestamp) = quest.expiry_timestamp {
             let current_time = env.ledger().timestamp();
-            if current_time >= expires_at {
+            if current_time >= expiry_timestamp {
                 env.events().publish(
                     (QUEST_EXPIRED, player.clone()),
-                    (chain_id, quest_id, expires_at),
+                    (chain_id, quest_id, expiry_timestamp),
                 );
                 panic!("Quest: expired");
             }
@@ -886,6 +886,39 @@ impl QuestChainContract {
         let mut config: ChainConfig = env.storage().persistent().get(&DataKey::Config).unwrap();
         config.reward_token = reward_token;
         env.storage().persistent().set(&DataKey::Config, &config);
+    }
+
+    /// Cancel all expired quests in a chain
+    pub fn cancel_expired_quests(env: Env, admin: Address, chain_id: u32) {
+        admin.require_auth();
+        Self::assert_owner(&env, &admin);
+
+        let mut chain: QuestChain = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Chain(chain_id))
+            .unwrap();
+
+        let current_time = env.ledger().timestamp();
+        let mut modified = false;
+        let mut new_quests = Vec::new(&env);
+
+        for quest in chain.quests.iter() {
+            let mut updated_quest = quest.clone();
+            if let Some(expiry_timestamp) = quest.expiry_timestamp {
+                if current_time >= expiry_timestamp && quest.status != QuestStatus::Completed && quest.status != QuestStatus::Locked {
+                    updated_quest.status = QuestStatus::Locked;
+                    modified = true;
+                    env.events().publish((QUEST_EXPIRED, admin.clone()), (chain_id, quest.id, expiry_timestamp));
+                }
+            }
+            new_quests.push_back(updated_quest);
+        }
+
+        if modified {
+            chain.quests = new_quests;
+            env.storage().persistent().set(&DataKey::Chain(chain_id), &chain);
+        }
     }
 
     /// Fund reward pool for a chain (owner only)

--- a/contracts/quest_chain/src/test.rs
+++ b/contracts/quest_chain/src/test.rs
@@ -29,7 +29,7 @@ fn create_test_quests(env: &Env) -> Vec<Quest> {
         prerequisites: Vec::new(env),
         branches: Vec::new(env),
         checkpoint: true,
-        expires_at: None,
+        expiry_timestamp: None,
     });
 
     // Quest 2: Requires quest 1
@@ -45,7 +45,7 @@ fn create_test_quests(env: &Env) -> Vec<Quest> {
         },
         branches: Vec::new(env),
         checkpoint: false,
-        expires_at: None,
+        expiry_timestamp: None,
     });
 
     // Quest 3: Also requires quest 1 (branching path)
@@ -61,7 +61,7 @@ fn create_test_quests(env: &Env) -> Vec<Quest> {
         },
         branches: Vec::new(env),
         checkpoint: true,
-        expires_at: None,
+        expiry_timestamp: None,
     });
 
     // Quest 4: Requires quest 2 OR quest 3 (branch merge)
@@ -81,7 +81,7 @@ fn create_test_quests(env: &Env) -> Vec<Quest> {
             branches
         },
         checkpoint: false,
-        expires_at: None,
+        expiry_timestamp: None,
     });
 
     // Quest 5: Final quest, requires quest 4
@@ -97,7 +97,7 @@ fn create_test_quests(env: &Env) -> Vec<Quest> {
         },
         branches: Vec::new(env),
         checkpoint: true,
-        expires_at: None,
+        expiry_timestamp: None,
     });
 
     quests
@@ -890,6 +890,88 @@ fn test_complete_quest_twice() {
 fn test_complete_unlocked_quest() {
     let env = Env::default();
     env.mock_all_auths();
+}
+
+#[test]
+fn test_quest_expiry_and_cancellation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let (client, admin) = setup_contract(&env);
+    
+    let mut quests = Vec::new(&env);
+    quests.push_back(Quest {
+        id: 1, puzzle_id: 101, reward: 100, status: QuestStatus::Locked,
+        prerequisites: Vec::new(&env), branches: Vec::new(&env), checkpoint: true,
+        expiry_timestamp: Some(2000), // Expires at 2000
+    });
+
+    let chain_id = client.create_chain(
+        &admin, &symbol_short!("Expiry"), &symbol_short!("expchn"),
+        &quests, &None, &None,
+    );
+
+    let player = Address::generate(&env);
+    client.start_chain(&player, &chain_id);
+    
+    // Complete before expiry succeeds
+    env.ledger().set_timestamp(1500);
+    client.complete_quest(&player, &chain_id, &1);
+
+    // Now test cancellation on a fresh chain
+    let mut quests2 = Vec::new(&env);
+    quests2.push_back(Quest {
+        id: 1, puzzle_id: 101, reward: 100, status: QuestStatus::Locked,
+        prerequisites: Vec::new(&env), branches: Vec::new(&env), checkpoint: true,
+        expiry_timestamp: Some(2500),
+    });
+
+    let chain_id_2 = client.create_chain(
+        &admin, &symbol_short!("Expiry2"), &symbol_short!("expchn2"),
+        &quests2, &None, &None,
+    );
+
+    let player2 = Address::generate(&env);
+    client.start_chain(&player2, &chain_id_2);
+
+    // Cancel expired quests after time passes
+    env.ledger().set_timestamp(3000);
+    client.cancel_expired_quests(&admin, &chain_id_2);
+
+    let chain = client.get_chain(&chain_id_2);
+    let q = chain.quests.get(0).unwrap();
+    assert_eq!(q.status, QuestStatus::Locked);
+}
+
+#[test]
+#[should_panic(expected = "Quest: expired")]
+fn test_complete_expired_quest() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let (client, admin) = setup_contract(&env);
+    
+    let mut quests = Vec::new(&env);
+    quests.push_back(Quest {
+        id: 1, puzzle_id: 101, reward: 100, status: QuestStatus::Locked,
+        prerequisites: Vec::new(&env), branches: Vec::new(&env), checkpoint: true,
+        expiry_timestamp: Some(1500), // Expires at 1500
+    });
+
+    let chain_id = client.create_chain(
+        &admin, &symbol_short!("Expiry"), &symbol_short!("expchn"),
+        &quests, &None, &None,
+    );
+
+    let player = Address::generate(&env);
+    client.start_chain(&player, &chain_id);
+
+    // Time passes expiry
+    env.ledger().set_timestamp(2000);
+    client.complete_quest(&player, &chain_id, &1);
+}
     env.ledger().set_timestamp(1000);
 
     let (client, admin) = setup_contract(&env);

--- a/contracts/referral_reward/lib.rs
+++ b/contracts/referral_reward/lib.rs
@@ -5,6 +5,7 @@ pub struct ReferralContract {
     pub stats: HashMap<String, (u64, u64)>, // referrer -> (count, total earned)
     pub reward_amount_referrer: u64,
     pub reward_amount_referee: u64,
+    pub max_reward_per_user: Option<u64>,
 }
 
 
@@ -15,6 +16,7 @@ impl ReferralContract {
             stats: HashMap::new(),
             reward_amount_referrer: referrer_reward,
             reward_amount_referee: referee_reward,
+            max_reward_per_user: None,
         }
     }
 }
@@ -46,14 +48,22 @@ impl ReferralContract {
             return Err("Reward already claimed".into());
         }
 
+        let entry = self.stats.entry(record.referrer.clone()).or_insert((0, 0));
+        let projected_total = entry.1 + record.reward_amount_referrer;
+
+        if let Some(cap) = self.max_reward_per_user {
+            if projected_total > cap {
+                return Err("Reward cap exceeded".into());
+            }
+        }
+
         // Transfer tokens (mocked here)
         self.transfer(&record.referrer, record.reward_amount_referrer)?;
         self.transfer(&record.referee, record.reward_amount_referee)?;
 
         record.rewarded_at = Some(now);
 
-        // Update stats
-        let entry = self.stats.entry(record.referrer.clone()).or_insert((0, 0));
+        // Update stats (already fetched as entry, just need to update it directly)
         entry.0 += 1;
         entry.1 += record.reward_amount_referrer;
 
@@ -84,4 +94,79 @@ impl ReferralContract {
     pub fn get_referral_stats(&self, referrer: String) -> (u64, u64) {
         self.stats.get(&referrer).cloned().unwrap_or((0, 0))
     }
+
+    pub fn update_reward_cap(&mut self, cap: Option<u64>) {
+        self.max_reward_per_user = cap;
+        println!("RewardCapUpdated: new_cap={:?}", cap);
+    }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock struct since it wasn't in lib.rs directly, we provide it to make it compile
+    pub struct ReferralRecord {
+        pub referrer: String,
+        pub referee: String,
+        pub rewarded_at: Option<u64>,
+        pub reward_amount_referrer: u64,
+        pub reward_amount_referee: u64,
+    }
+
+    #[test]
+    fn test_reward_cap_exceeded() {
+        let mut contract = ReferralContract::new(50, 10);
+        contract.update_reward_cap(Some(80));
+
+        let ref1 = "user1".to_string();
+        let ref2 = "user2".to_string();
+        let referrer = "alice".to_string();
+
+        // Register 2 referrals
+        contract.referrals.insert(ref1.clone(), ReferralRecord {
+            referrer: referrer.clone(), referee: ref1.clone(), rewarded_at: None,
+            reward_amount_referrer: 50, reward_amount_referee: 10,
+        });
+        contract.referrals.insert(ref2.clone(), ReferralRecord {
+            referrer: referrer.clone(), referee: ref2.clone(), rewarded_at: None,
+            reward_amount_referrer: 50, reward_amount_referee: 10,
+        });
+
+        // First claim should succeed (50 <= 80)
+        assert!(contract.claim_referral_reward(ref1, 100).is_ok());
+        
+        // Second claim should fail (50 + 50 = 100 > 80)
+        let result = contract.claim_referral_reward(ref2, 101);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Reward cap exceeded");
+    }
+
+    #[test]
+    fn test_cap_update_scenario() {
+        let mut contract = ReferralContract::new(50, 10);
+        let referrer = "alice".to_string();
+        let ref1 = "user1".to_string();
+        let ref2 = "user2".to_string();
+
+        contract.referrals.insert(ref1.clone(), ReferralRecord {
+            referrer: referrer.clone(), referee: ref1.clone(), rewarded_at: None,
+            reward_amount_referrer: 50, reward_amount_referee: 10,
+        });
+        contract.referrals.insert(ref2.clone(), ReferralRecord {
+            referrer: referrer.clone(), referee: ref2.clone(), rewarded_at: None,
+            reward_amount_referrer: 50, reward_amount_referee: 10,
+        });
+
+        contract.update_reward_cap(Some(50));
+        assert!(contract.claim_referral_reward(ref1, 100).is_ok());
+
+        // Fails due to cap
+        assert!(contract.claim_referral_reward(ref2.clone(), 101).is_err());
+
+        // Increase cap
+        contract.update_reward_cap(Some(100));
+        assert!(contract.claim_referral_reward(ref2, 102).is_ok());
+    }
+}
+


### PR DESCRIPTION
## Description

This PR introduces comprehensive updates across multiple contracts to enforce safety limits, timeouts, and multi-sig treasury governance.

### Changes
*   **Quest Expiry (#241)**: Renamed `expires_at` to `expiry_timestamp` in `Quest` struct. Added `cancel_expired_quests` admin function to safely garbage-collect and lock expired quests, preventing completion after their timestamp.
*   **Referral Reward Cap (#242)**: Added a dynamic `max_reward_per_user` cap in `ReferralContract`. Includes `update_reward_cap` for runtime admin overrides and explicitly rejects any claims that cross the limit threshold.
*   **Guild Treasury Withdrawals (#243)**: Upgraded `GuildContract` withdrawals from immediate execution to a formalized `WithdrawalProposal` flow. If a withdrawal exceeds `withdrawal_threshold`, it spawns a voting round requiring a strict 51% member majority before execution.

Closes #241
Closes #242
Closes #243
