### PR TITLE
feat: Add quest emergency pause controls

### DIFF
--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -355,6 +355,25 @@ impl QuestContract {
         effective_reward
     }
 
+    /// Mark a quest as completed by `participant`.
+    ///
+    /// Sensitive: rejected while the contract is paused.
+    pub fn complete_quest(env: Env, participant: Address, quest_id: u64) {
+        require_not_paused(&env);
+        participant.require_auth();
+
+        let mut quest: Quest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Quest(quest_id))
+            .unwrap_or_else(|| panic_with_error(&env, QuestError::QuestNotFound));
+
+        quest.status = QuestStatus::Completed;
+        save_quest(&env, &quest);
+
+        events::quest_completed(&env, quest_id, participant);
+    }
+
     /// Returns whether `participant` has already claimed the reward for
     /// `quest_id`.
     pub fn has_claimed(env: Env, participant: Address, quest_id: u64) -> bool {

--- a/contracts/quest/src/test.rs
+++ b/contracts/quest/src/test.rs
@@ -590,6 +590,31 @@ fn admin_can_pause_and_unpause() {
 
 #[test]
 #[should_panic(expected = "quest contract error")]
+fn non_admin_cannot_pause() {
+    let (env, _id, _admin, _creator, client) = setup_initialized();
+    let stranger = Address::generate(&env);
+
+    client.pause(&stranger);
+}
+
+#[test]
+fn create_quest_allowed_when_unpaused() {
+    let (env, _id, _admin, creator, client) = setup_initialized();
+
+    let quest_id = client.create_quest(
+        &creator,
+        &s(&env, "Title"),
+        &s(&env, "desc"),
+        &Vec::<String>::new(&env),
+        &10_i128,
+        &Difficulty::Easy,
+    );
+
+    assert_eq!(client.get_quest(&quest_id).status, QuestStatus::Active);
+}
+
+#[test]
+#[should_panic(expected = "quest contract error")]
 fn create_quest_blocked_while_paused() {
     let (env, _id, admin, creator, client) = setup_initialized();
     client.pause(&admin);
@@ -621,4 +646,43 @@ fn batch_create_blocked_while_paused() {
         },
     ];
     client.create_quest_batch(&creator, &inputs);
+}
+
+#[test]
+fn complete_quest_allowed_when_unpaused() {
+    let (env, _id, _admin, creator, client) = setup_initialized();
+    let player = Address::generate(&env);
+
+    let quest_id = client.create_quest(
+        &creator,
+        &s(&env, "Title"),
+        &s(&env, "desc"),
+        &Vec::<String>::new(&env),
+        &10_i128,
+        &Difficulty::Easy,
+    );
+
+    client.complete_quest(&player, &quest_id);
+
+    assert_eq!(client.get_quest(&quest_id).status, QuestStatus::Completed);
+}
+
+#[test]
+#[should_panic(expected = "quest contract error")]
+fn complete_quest_blocked_while_paused() {
+    let (env, _id, admin, creator, client) = setup_initialized();
+    let player = Address::generate(&env);
+
+    let quest_id = client.create_quest(
+        &creator,
+        &s(&env, "Title"),
+        &s(&env, "desc"),
+        &Vec::<String>::new(&env),
+        &10_i128,
+        &Difficulty::Easy,
+    );
+
+    client.pause(&admin);
+
+    client.complete_quest(&player, &quest_id);
 }


### PR DESCRIPTION
Description
Implements the emergency pause mechanism for the quest contract so admins can halt sensitive quest operations if an exploit or incident is discovered.

Changes

Added complete_quest entrypoint.
Guarded complete_quest with the existing pause check.
Confirmed create_quest reverts while paused.
Added non-admin pause rejection coverage.
Added tests for paused and unpaused quest creation/completion behavior.
Testing

cargo fmt -p quest --check
cargo test -p quest
Result: 32 passed, 0 failed

closes #240 