### PR TITLE
chore: standardize error handling across quest, flash_challenge, and …

### DIFF
--- a/contracts/auction/src/lib.rs
+++ b/contracts/auction/src/lib.rs
@@ -1,7 +1,27 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, IntoVal, Symbol, Val,
+    contract, contractimpl, contracttype, token, Address, Env, IntoVal, Symbol,
 };
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AuctionError {
+    EndTimeMustBeAfterStartTime = 1,
+    AuctionNotFound = 2,
+    EnglishOnly = 3,
+    AuctionAlreadySettled = 4,
+    AuctionNotStarted = 5,
+    AuctionEnded = 6,
+    BidTooLow = 7,
+    DutchOnly = 8,
+    CurrentPriceHigherThanMax = 9,
+    AuctionStillOngoing = 10,
+}
+
+fn panic_with_error(env: &Env, err: AuctionError) -> ! {
+    env.events().publish(("auction_error",), err as u32);
+    panic!("auction contract error");
+}
 
 // 1. DATA STRUCTURES
 #[contracttype]
@@ -71,7 +91,7 @@ impl AuctionContract {
         seller.require_auth();
 
         if settings.end_time <= settings.start_time {
-            panic!("End time must be after start time");
+            panic_with_error(&env, AuctionError::EndTimeMustBeAfterStartTime);
         }
 
         // Generate ID
@@ -116,22 +136,22 @@ impl AuctionContract {
             .storage()
             .instance()
             .get(&DataKey::Auction(auction_id))
-            .unwrap();
+            .unwrap_or_else(|| panic_with_error(&env, AuctionError::AuctionNotFound));
 
         // 3. Validation Checks
         if auction.auction_type != AuctionType::English {
-            panic!("This function is for English auctions only");
+            panic_with_error(&env, AuctionError::EnglishOnly);
         }
         if auction.settled {
-            panic!("Auction is already settled");
+            panic_with_error(&env, AuctionError::AuctionAlreadySettled);
         }
 
         let current_time = env.ledger().timestamp();
         if current_time < auction.settings.start_time {
-            panic!("Auction has not started yet");
+            panic_with_error(&env, AuctionError::AuctionNotStarted);
         }
         if current_time > auction.settings.end_time {
-            panic!("Auction has ended");
+            panic_with_error(&env, AuctionError::AuctionEnded);
         }
 
         // 4. Price Logic & Refunds
@@ -141,7 +161,7 @@ impl AuctionContract {
             // CASE A: Outbidding someone
             // Check if bid is high enough (Current Bid + Increment)
             if bid_amount < auction.current_bid + auction.settings.min_bid_increment {
-                panic!("Bid too low: must meet min increment");
+                panic_with_error(&env, AuctionError::BidTooLow);
             }
 
             // Refund the previous bidder!
@@ -154,7 +174,7 @@ impl AuctionContract {
         } else {
             // CASE B: First bid of the auction
             if bid_amount < auction.settings.starting_price {
-                panic!("Bid below starting price");
+                panic_with_error(&env, AuctionError::BidTooLow);
             }
         }
 
@@ -209,14 +229,14 @@ impl AuctionContract {
             .storage()
             .instance()
             .get(&DataKey::Auction(auction_id))
-            .unwrap();
+            .unwrap_or_else(|| panic_with_error(&env, AuctionError::AuctionNotFound));
 
         // 1. Validation
         if auction.auction_type != AuctionType::Dutch {
-            panic!("This function is for Dutch auctions only");
+            panic_with_error(&env, AuctionError::DutchOnly);
         }
         if auction.settled {
-            panic!("Auction is already settled");
+            panic_with_error(&env, AuctionError::AuctionAlreadySettled);
         }
 
         // 2. Calculate Price
@@ -226,7 +246,7 @@ impl AuctionContract {
         // 3. Check Price Acceptability
         // The buyer says "I will pay up to X". If current price is higher, fail.
         if current_price > max_amount {
-            panic!("Current price is higher than your max limit");
+            panic_with_error(&env, AuctionError::CurrentPriceHigherThanMax);
         }
 
         // 4. Process Payment
@@ -250,16 +270,16 @@ impl AuctionContract {
             .storage()
             .instance()
             .get(&DataKey::Auction(auction_id))
-            .unwrap();
+            .unwrap_or_else(|| panic_with_error(&env, AuctionError::AuctionNotFound));
 
         if auction.settled {
-            panic!("Auction is already settled");
+            panic_with_error(&env, AuctionError::AuctionAlreadySettled);
         }
 
         // For English auctions, ensure time has passed
         if auction.auction_type == AuctionType::English {
             if env.ledger().timestamp() < auction.settings.end_time {
-                panic!("Auction is still ongoing");
+                panic_with_error(&env, AuctionError::AuctionStillOngoing);
             }
         }
 

--- a/contracts/flash_challenge/src/lib.rs
+++ b/contracts/flash_challenge/src/lib.rs
@@ -4,9 +4,29 @@ mod storage;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec, symbol_short, BytesN, Symbol, IntoVal};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec, symbol_short, BytesN, Symbol, IntoVal};
 use soroban_sdk::token::Client as TokenClient;
 use crate::storage::*;
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FlashChallengeError {
+    AlreadyInitialized = 1,
+    InvalidParameters = 2,
+    ChallengeNotFound = 3,
+    ChallengeNotActive = 4,
+    ChallengeNotStarted = 5,
+    ChallengeExpired = 6,
+    AlreadyWinner = 7,
+    IncorrectSolution = 8,
+    ChallengeNotEnded = 9,
+    AlreadyFinalized = 10,
+}
+
+fn panic_with_error(env: &Env, err: FlashChallengeError) -> ! {
+    env.events().publish(("flash_challenge_error",), err as u32);
+    panic!("flash challenge contract error");
+}
 
 #[contract]
 pub struct FlashChallengeContract;
@@ -15,7 +35,7 @@ pub struct FlashChallengeContract;
 impl FlashChallengeContract {
     pub fn initialize(env: Env, admin: Address, token: Address, oracle: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
+            panic_with_error(&env, FlashChallengeError::AlreadyInitialized);
         }
         set_admin(&env, &admin);
         set_token_address(&env, &token);
@@ -34,7 +54,7 @@ impl FlashChallengeContract {
         admin.require_auth();
 
         if reward_pool <= 0 || max_winners == 0 || duration_minutes == 0 {
-            panic!("Invalid parameters");
+            panic_with_error(&env, FlashChallengeError::InvalidParameters);
         }
 
         let token = get_token_address(&env);
@@ -67,19 +87,19 @@ impl FlashChallengeContract {
     pub fn submit_solution(env: Env, challenge_id: u32, player: Address, solution_hash: BytesN<32>) {
         player.require_auth();
 
-        let mut challenge = get_challenge(&env, challenge_id).expect("Challenge not found");
+        let mut challenge = get_challenge(&env, challenge_id).unwrap_or_else(|| panic_with_error(&env, FlashChallengeError::ChallengeNotFound));
         
         if challenge.status == ChallengeStatus::Completed || challenge.status == ChallengeStatus::Expired {
-            panic!("Challenge not active");
+            panic_with_error(&env, FlashChallengeError::ChallengeNotActive);
         }
 
         let now = env.ledger().timestamp();
         if now < challenge.start_at {
-            panic!("Challenge hasn't started");
+            panic_with_error(&env, FlashChallengeError::ChallengeNotStarted);
         }
         
         if now > challenge.end_at {
-            panic!("Challenge expired");
+            panic_with_error(&env, FlashChallengeError::ChallengeExpired);
         }
         
         if challenge.status == ChallengeStatus::Scheduled {
@@ -87,7 +107,7 @@ impl FlashChallengeContract {
         }
 
         if challenge.winners.contains(&player) {
-            panic!("Already a winner");
+            panic_with_error(&env, FlashChallengeError::AlreadyWinner);
         }
 
         // Oracle verifies
@@ -99,7 +119,7 @@ impl FlashChallengeContract {
         );
 
         if !is_correct {
-            panic!("Incorrect solution");
+            panic_with_error(&env, FlashChallengeError::IncorrectSolution);
         }
 
         challenge.winners.push_back(player.clone());
@@ -127,15 +147,15 @@ impl FlashChallengeContract {
     }
     
     pub fn expire_challenge(env: Env, challenge_id: u32) {
-        let mut challenge = get_challenge(&env, challenge_id).expect("Challenge not found");
+        let mut challenge = get_challenge(&env, challenge_id).unwrap_or_else(|| panic_with_error(&env, FlashChallengeError::ChallengeNotFound));
         let now = env.ledger().timestamp();
         
         if now <= challenge.end_at {
-            panic!("Challenge has not ended yet");
+            panic_with_error(&env, FlashChallengeError::ChallengeNotEnded);
         }
         
         if challenge.status == ChallengeStatus::Completed || challenge.status == ChallengeStatus::Expired {
-            panic!("Already finalized");
+            panic_with_error(&env, FlashChallengeError::AlreadyFinalized);
         }
         
         challenge.status = ChallengeStatus::Expired;
@@ -164,7 +184,7 @@ impl FlashChallengeContract {
     }
 
     pub fn get_challenge(env: Env, id: u32) -> (ChallengeStatus, Vec<Address>, u64) {
-        let challenge = get_challenge(&env, id).expect("Not found");
+        let challenge = get_challenge(&env, id).unwrap_or_else(|| panic_with_error(&env, FlashChallengeError::ChallengeNotFound));
         let now = env.ledger().timestamp();
         let mut time_remaining = 0;
         

--- a/contracts/quest/src/lib.rs
+++ b/contracts/quest/src/lib.rs
@@ -86,6 +86,8 @@ pub struct Quest {
     /// Categories/tags assigned to the quest at creation time.
     pub tags: Vec<String>,
     pub rewards: Vec<Reward>,
+    pub reward: i128,
+    pub difficulty: Difficulty,
     pub status: QuestStatus,
     pub created_at: u64,
 }
@@ -99,6 +101,7 @@ pub struct QuestInput {
     pub tags: Vec<String>,
     pub reward: i128,
     pub difficulty: Difficulty,
+    pub rewards: Vec<Reward>,
 }
 
 //
@@ -224,6 +227,8 @@ impl QuestContract {
         description: String,
         tags: Vec<String>,
         rewards: Vec<Reward>,
+        reward: i128,
+        difficulty: Difficulty,
     ) -> u64 {
         require_not_paused(&env);
         creator.require_auth();
@@ -250,6 +255,8 @@ impl QuestContract {
             description,
             tags: tags.clone(),
             rewards,
+            reward,
+            difficulty,
             status: QuestStatus::Active,
             created_at: env.ledger().timestamp(),
         };
@@ -309,6 +316,7 @@ impl QuestContract {
                 title: q.title,
                 description: q.description,
                 tags: q.tags.clone(),
+                rewards: q.rewards.clone(),
                 reward: q.reward,
                 difficulty: q.difficulty,
                 status: QuestStatus::Active,


### PR DESCRIPTION
- quest contract: fix Quest struct (adds reward & difficulty), fix create_quest params, update create_quest_batch
- flash_challenge contract: add FlashChallengeError enum + panic_with_error helper
- auction contract: add AuctionError enum + panic_with_error helper, remove unused Val import

All errors now emit events with numeric codes for better debugging
Closes #211 